### PR TITLE
feat: Implement CompressedCborCodec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,87 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "cbor": "^10.0.11",
+        "pako": "^2.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.1",
+        "@types/pako": "^2.0.4",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cbor": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.11.tgz",
+      "integrity": "sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "A real-time multiplayer web-based pong-game",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keelbismark/Transcendence.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/keelbismark/Transcendence/issues"
+  },
+  "homepage": "https://github.com/keelbismark/Transcendence#readme",
+  "dependencies": {
+    "cbor": "^10.0.11",
+    "pako": "^2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "@types/pako": "^2.0.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/src/CompressedCborCodec.ts
+++ b/src/CompressedCborCodec.ts
@@ -1,0 +1,15 @@
+import * as cbor from 'cbor';
+import * as pako from 'pako';
+
+export class CompressedCborCodec {
+  encode(data: any): Buffer {
+    const cborData = cbor.encode(data);
+    const compressedData = pako.deflate(cborData);
+    return Buffer.from(compressedData);
+  }
+
+  decode(buffer: Buffer): any {
+    const decompressedData = pako.inflate(buffer);
+    return cbor.decode(Buffer.from(decompressedData));
+  }
+}

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,15 @@
+import { CompressedCborCodec } from './CompressedCborCodec';
+
+const codec = new CompressedCborCodec();
+
+const data = {
+  name: 'John Doe',
+  age: 30,
+  isStudent: false,
+};
+
+const encodedData = codec.encode(data);
+console.log('Encoded:', encodedData);
+
+const decodedData = codec.decode(encodedData);
+console.log('Decoded:', decodedData);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strict": true
+  }
+}


### PR DESCRIPTION
This commit introduces a `CompressedCborCodec` for serializing and compressing data for WebTransport binary streams.

The implementation includes:
- A `CompressedCborCodec` class with `encode` and `decode` methods.
- The `cbor` library for serialization.
- The `pako` library for compression.
- An example of how to use the codec.