### PR TITLE
chore(docs): introduce how-to pages for salvo routes, validation, and database ORM

### DIFF
--- a/docs/how-to/database-and-models.md
+++ b/docs/how-to/database-and-models.md
@@ -1,0 +1,151 @@
+# How-To: Database & Models (Diesel)
+
+This guide explains how to add new tables and interact with the database using Diesel ORM.
+
+## 1. The Workflow
+
+Working with the database involves 3 steps:
+
+1. **Migration**: Create a SQL file to define the table.
+2. **Schema**: Diesel automatically updates `src/schema.rs` when you run the migration.
+3. **Model**: You define Rust structs in `src/models.rs` to represent the data.
+
+## 2. Creating a New Table (Migration)
+
+1. **Generate the migration files**:
+   Run this command in the `backend` folder:
+
+   ```bash
+   diesel migration generate create_tasks
+   ```
+
+2. **Edit the SQL**:
+   This creates a folder in `migrations/`. Edit `up.sql` to create the table:
+
+   ```sql
+   -- up.sql
+   CREATE TABLE tasks (
+       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+       title TEXT NOT NULL,
+       is_completed BOOLEAN NOT NULL DEFAULT 0
+   );
+   ```
+
+   And `down.sql` to undo it (important for rolling back):
+
+   ```sql
+   -- down.sql
+   DROP TABLE tasks;
+   ```
+
+3. **Apply the migration**:
+
+   ```bash
+   diesel migration run
+   ```
+
+   *This will update `src/schema.rs` automatically.*
+
+## 3. Defining the Model (Structs)
+
+In `src/models.rs`, define structs that match your table.
+
+```rust
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+use crate::schema::tasks; // Import the table schema
+
+// 1. Struct for READING data (Queryable)
+// Must match the table columns exactly in order and type.
+#[derive(Queryable, Selectable, Serialize, Debug)]
+#[diesel(table_name = tasks)]
+pub struct Task {
+    pub id: i32,
+    pub title: String,
+    pub is_completed: bool,
+}
+
+// 2. Struct for INSERTING data (Insertable)
+// Usually doesn't have 'id' because the DB generates it.
+#[derive(Insertable, Deserialize)]
+#[diesel(table_name = tasks)]
+pub struct NewTask {
+    pub title: String,
+    pub is_completed: bool,
+}
+```
+
+## 4. CRUD Operations
+
+Here is how to use these models in your code (e.g., in a Route Handler).
+
+First, always import the necessary parts:
+
+```rust
+use diesel::prelude::*;
+use crate::db;
+use crate::models::{Task, NewTask};
+use crate::schema::tasks::dsl::*; // Import table columns (id, title, etc.)
+```
+
+### Create (Insert)
+
+```rust
+pub fn create_task(new_title: String) -> Result<(), diesel::result::Error> {
+    let new_task = NewTask {
+        title: new_title,
+        is_completed: false,
+    };
+
+    let conn = &mut db::get().unwrap(); // Get DB connection
+
+    diesel::insert_into(tasks)
+        .values(&new_task)
+        .execute(conn)?;
+        
+    Ok(())
+}
+```
+
+### Read (Select)
+
+```rust
+pub fn get_all_tasks() -> Vec<Task> {
+    let conn = &mut db::get().unwrap();
+
+    // Load all tasks
+    tasks.load::<Task>(conn).expect("Error loading tasks")
+}
+
+pub fn get_task_by_id(task_id: i32) -> Option<Task> {
+    let conn = &mut db::get().unwrap();
+
+    // Find one by ID
+    tasks.find(task_id).first::<Task>(conn).ok()
+}
+```
+
+### Update
+
+```rust
+pub fn complete_task(task_id: i32) {
+    let conn = &mut db::get().unwrap();
+
+    diesel::update(tasks.find(task_id))
+        .set(is_completed.eq(true))
+        .execute(conn)
+        .expect("Error updating task");
+}
+```
+
+### Delete
+
+```rust
+pub fn delete_task(task_id: i32) {
+    let conn = &mut db::get().unwrap();
+
+    diesel::delete(tasks.find(task_id))
+        .execute(conn)
+        .expect("Error deleting task");
+}
+```

--- a/docs/how-to/salvo-routes-advanced.md
+++ b/docs/how-to/salvo-routes-advanced.md
@@ -1,0 +1,139 @@
+# Advanced Salvo Routes
+
+This guide covers more advanced topics for building robust API endpoints in Salvo, including OpenAPI documentation, error handling, input validation, and database access.
+
+## 1. OpenAPI Documentation (`#[endpoint]`)
+
+To automatically generate API documentation (Scalar, Swagger UI, ...), use the `#[endpoint]` macro instead of `#[handler]`. This allows you to describe your API structure.
+
+```rust
+use salvo::oapi::extract::JsonBody;
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+use salvo::oapi::ToSchema; // Required for OpenAPI
+
+#[derive(Deserialize, Serialize, ToSchema)]
+struct CreateTask {
+    title: String,
+    description: String,
+}
+
+#[derive(Serialize, ToSchema)]
+struct TaskResponse {
+    id: i32,
+    title: String,
+    completed: bool,
+}
+
+// Use #[endpoint] to expose this handler to OpenAPI
+// You can add summary, description, and other metadata
+#[endpoint(
+    summary = "Create a new task",
+    description = "Creates a task and returns the created task details"
+)]
+async fn create_task(task: JsonBody<CreateTask>) -> Json<TaskResponse> {
+    let task = task.into_inner();
+
+    // ... logic to save task ...
+
+    Json(TaskResponse {
+        id: 1,
+        title: task.title,
+        completed: false,
+    })
+}
+```
+
+## 2. Input Validation
+
+We use the `validator` crate to ensure data is correct before processing it.
+
+```rust
+use validator::Validate;
+use salvo::oapi::extract::JsonBody;
+use salvo::prelude::*;
+
+#[derive(Deserialize, Validate, ToSchema)]
+struct UserSignup {
+    #[validate(email(message = "Invalid email format"))]
+    email: String,
+
+    #[validate(length(min = 8, message = "Password must be at least 8 chars"))]
+    password: String,
+}
+
+#[endpoint]
+async fn signup(user: JsonBody<UserSignup>) -> Result<StatusCode, String> {
+    let user_data = user.into_inner();
+
+    // Validate the struct
+    if let Err(e) = user_data.validate() {
+        return Err(format!("Validation error: {}", e));
+    }
+
+    Ok(StatusCode::CREATED)
+}
+```
+
+## 3. Error Handling with `Result`
+
+Instead of panicking or returning simple strings, return a `Result`. This allows you to return successful data or an error status code/message.
+
+In our project, we often use a custom error type (like `ApiError`) that converts to a response automatically.
+
+```rust
+use salvo::prelude::*;
+
+// Simple example using standard Result
+#[endpoint]
+async fn divide(req: &mut Request) -> Result<String, StatusCode> {
+    let a = req.query::<f64>("a").unwrap_or(0.0);
+    let b = req.query::<f64>("b").unwrap_or(0.0);
+
+    if b == 0.0 {
+        // Return a 400 Bad Request status
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    Ok(format!("Result: {}", a / b))
+}
+```
+
+## 4. Accessing the Database
+
+To access the database, we usually don't pass the connection pool in the request. Instead, we use a global helper or a state accessor. In this project, we use `crate::db::get()` to get a connection.
+
+```rust
+use crate::db;
+use diesel::prelude::*;
+use salvo::prelude::*;
+
+#[endpoint]
+async fn get_users() -> Result<Json<Vec<String>>, StatusCode> {
+    // Get a database connection
+    // The `?` operator handles the error if getting a connection fails
+    let mut conn = db::get().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // ... perform diesel queries using `conn` ...
+
+    Ok(Json(vec!["Alice".to_string(), "Bob".to_string()]))
+}
+```
+
+## 5. Authentication (Guards)
+
+To protect a route so only logged-in users can access it, we use "Hoops" (Middleware).
+
+```rust
+use salvo::prelude::*;
+
+#[endpoint]
+async fn protected_data() -> &'static str {
+    "This data is for logged-in users only."
+}
+
+// In your router configuration:
+// Router::with_path("protected")
+//     .hoop(crate::hoops::auth::auth_check) // Apply the auth middleware
+//     .get(protected_data);
+```

--- a/docs/how-to/salvo-routes.md
+++ b/docs/how-to/salvo-routes.md
@@ -1,0 +1,141 @@
+# How-To: Make a Route Handler
+
+## Salvo Guides
+
+<https://salvo.rs/guide/>
+
+## Extensive Examples for every usecase directly from the salvo makers
+
+<https://github.com/salvo-rs/salvo/tree/main/examples>
+
+## Basic Handler and Router
+
+```rust
+use salvo::prelude::*;
+
+// A basic handler that responds with "Hello, World!"
+#[handler]
+async fn my_hello_world_handler() -> &'static str {
+    "Hello, World!"
+}
+
+// When using this router to serve under root,
+// this will install the hello_world handler for GET "/hello-world"
+Router::with_path("hello-world").get(my_hello_world_handler);
+```
+
+## Handler which returns Json Data
+
+```rust
+use salvo::prelude::*;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct MyData {
+    my_message: String,
+    a_number: i32,
+}
+
+// A handler that returns JSON data
+// (automatically serialized through the derived Serialize trait)
+#[handler]
+async fn json_response() -> Json<MyData> {
+    let data = MyData {
+        my_message: "Hello, JSON!".to_string(),
+        a_number: 42,
+    };
+
+    Json(data)
+    // or `return Json(data);`
+    // (the last expression in a function is returned implicitly in rust)
+}
+
+// Usage: Router::with_path("api/data").get(json_response);
+```
+
+## Handler which extracts simple Data
+
+```rust
+use salvo::prelude::*;
+
+// A handler that extracts a query parameter "name"
+// and responds with a greeting message
+// Example request if the handler is installed under the path "/greet":
+// GET /greet?name=Alice
+#[handler]
+async fn greet(request: &mut Request) -> String {
+    // Extract the "name" query parameter from the request
+    // If not present, default to "unnamed"
+    let name = request.query::<String>("name").unwrap_or("unnamed".to_string());
+
+    // Return a greeting message
+    format!("Hello, {name}!")
+}
+
+// Usage: Router::with_path("greet").get(greet);
+```
+
+## Handler which extracts a Json object manually (The Hard Way)
+
+> **Note:** This is useful to understand how it works under the hood, but prefer the "Extractor" method below.
+
+```rust
+use salvo::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// We need to derive the `Deserialize` Trait to parse JSON into this struct
+// and we need `Serialize` to send it back as JSON
+#[derive(Deserialize, Serialize)]
+struct User {
+    name: String,
+    age: u8,
+}
+
+#[handler]
+async fn echo_json_user(request: &mut Request) -> Json<User> {
+    // Extract JSON data from the request body into a User struct
+    // WARNING: .unwrap() will panic and crash the handler if the sent JSON is invalid!
+    let data: User = request.parse_json::<User>().await.unwrap();
+    // Just echo it back as JSON
+    Json(data)
+}
+
+// This function avoids crashing the whole server,
+// if parsing the User Json fails (because of the usage of `.unwrap()` above)
+async fn echo_json_user_error_handled(request: &mut Request) -> Result<Json<User>, salvo::http::ParseError> {
+    // Extract JSON data from the request body into a User struct
+    // The `?` operator returns the error if parsing fails
+    let data: User = request.parse_json::<User>().await?;
+    // Just echo it back as JSON
+    Ok(Json(data))
+}
+```
+
+## The Recommended Way: Using Extractors (`JsonBody`)
+
+This is the standard way to handle data in Salvo. It handles parsing and errors for you.
+
+[Salvo Guide - Built-in extractors](https://salvo.rs/guide/concepts/request.html#built-in-extractors)
+
+```rust
+use salvo::{oapi::extract::JsonBody, prelude::*};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct User {
+    name: String,
+    age: u8,
+}
+
+// Parsing errors are automatically handled by Salvo when using the `JsonBody` extractor
+#[handler]
+async fn echo_json_user(user: JsonBody<User>) -> Json<User> {
+    // `user` is a wrapper. Use `.into_inner()` to get your actual struct.
+    let user_data = user.into_inner();
+
+    // Just echo it back as JSON
+    Json(user_data)
+}
+
+// Usage: Router::with_path("user").post(echo_json_user);
+```


### PR DESCRIPTION
This pull request adds three new documentation guides to the `docs/how-to` (#9) directory, providing step-by-step instructions for common backend development tasks using Rust, Salvo, and Diesel. These guides cover basic and advanced API routing with Salvo, as well as database modeling and CRUD operations with Diesel ORM.

### Salvo Routing Documentation

* Added `salvo-routes.md` to explain how to create basic route handlers, extract data from requests, handle JSON payloads, and use extractors for cleaner code. Includes practical code examples for each scenario.
* Added `salvo-routes-advanced.md` to cover advanced topics such as OpenAPI documentation generation, input validation with the `validator` crate, structured error handling, database access patterns, and route protection using middleware ("Hoops").

### Diesel ORM & Database Guide

* Added `database-and-models.md` to provide a comprehensive workflow for adding tables, defining models, and implementing CRUD operations using Diesel. The guide includes migration steps, model struct definitions, and example functions for create, read, update, and delete operations.