### PR TITLE
Fix Timestamps to include timezone info and add new needed customized db migration flow

### DIFF
--- a/backend/WHEN_CHANGING_MIGRATIONS_READ_THIS.md
+++ b/backend/WHEN_CHANGING_MIGRATIONS_READ_THIS.md
@@ -1,0 +1,1 @@
+migrations/README.md

--- a/backend/diesel.toml
+++ b/backend/diesel.toml
@@ -3,6 +3,7 @@
 
 [print_schema]
 file = "src/schema.rs"
+patch_file = "src/schema.patch"
 custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
 
 [migrations_directory]

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -1,143 +1,33 @@
-Diesel CLI
-==========
+# Migration Workflow
 
-Diesel CLI is a tool that aids in managing your database schema. Migrations are
-bi-directional changes to your database that get applied sequentially.
+This folder contains Diesel migrations for the backend SQLite database.
 
-Installation
----------------
+## Rule for this project
 
-The diesel cli, by default, requires [`openssl`][openssl], [`libpq`][postgres],
-[`sqlite`][sqlite], and [`mysql`][mysql]. Once these dependencies are installed,
-you can run `cargo install diesel_cli`.
-
-> Note: Make sure that both the `bin` and `lib` directories for
-> postgres are added to your PATH
-
-To install the cli without these dependencies, omit the unneeded dependencies from
-the following command:
+When you change migrations (`up.sql` or `down.sql`), you must run:
 
 ```sh
-cargo install diesel_cli --no-default-features --features "postgres sqlite mysql"
+backend/scripts/run_migrations_update_schema.sh
 ```
 
-[openssl]: https://www.openssl.org/source
-[postgres]: https://www.postgresql.org/download/
-[sqlite]: http://www.sqlitetutorial.net/download-install-sqlite/
-[mysql]: https://dev.mysql.com/doc/refman/5.7/en/installing.html
+This is the project-standard command for:
 
-If you are using a system without an easy way to install sqlite (for example Windows),
-you can use a bundled version instead:
+1. applying migration changes to the local database,
+2. regenerating `backend/src/schema.rs`,
+3. regenerating `backend/src/schema.patch` (timestamp mapping patch).
 
-```shell
-cargo install diesel_cli --no-default-features --features "sqlite-bundled"
-```
+Do not manually edit `backend/src/schema.rs` and expect it to persist. It is generated.
 
-Getting Started
----------------
+## Typical flow
 
-```sh
-cargo install diesel_cli
-diesel setup --database-url='postgres://localhost/my_db'
-diesel migration generate create_users_table
-```
+1. Create or edit migration files in this directory.
+2. Run `backend/scripts/run_migrations_update_schema.sh`.
+3. Review changes in:
+   - `backend/src/schema.rs`
+   - `backend/src/schema.patch`
+4. Commit migration files together with schema/patch updates.
 
-You'll see that a `migrations/` directory was generated for you (by the setup
-command), and two sql files were generated,
-`migrations/{current_timestamp}_create_users_table/up.sql` and
-`migrations/{current_timestamp}_create_users_table/down.sql`. You should edit
-these files to show how to update your schema, and how to undo that change.
+## If migration commands fail
 
-```sql
--- up.sql
-CREATE TABLE users (
-    id SERIAL PRIMARY KEY,
-    name VARCHAR NOT NULL,
-    favorite_color VARCHAR
-);
-```
-
-```sql
--- down.sql
-DROP TABLE USERS;
-```
-
-You can then run your new migration by running `diesel migration run`. Your
-DATABASE_URL must be set in order to run this command, and there are several
-ways that you can set it:
-
-* Set it as an environment variable manually
-* Set it as an environment variable using [dotenv](https://github.com/dotenv-rs/dotenv#examples)
-* Pass it directly by adding the `--database-url` flag
-
-As an alternative to running migrations with the CLI, you can call
-[`diesel::migrations::run_pending_migrations`][pending-migrations] from
-`build.rs`.
-
-Diesel will automatically keep track of which migrations have already been run,
-ensuring that they're never run twice.
-
-Commands
---------
-
-## `diesel setup`
-Searches for a `migrations/` directory, and if it can't find one, creates one
-in the same directory as the first `Cargo.toml` it finds.  It then tries to
-connect to the provided DATABASE_URL, and will create the given database if it
-cannot connect to it. Finally it will create diesel's internal table for
-tracking which migrations have been run, and run any existing migrations if the
-internal table did not previously exist.
-
-## `diesel database`
-#### `database setup`
-Tries to connect to the provided DATABASE_URL, and will create the given
-database if it cannot connect to it.  It then creates diesel's internal
-migrations tracking table if it needs to be created, and runs any pending
-migrations if it created the internal table.
-
-#### `database reset`
-Drops the database specified in your DATABASE_URL if it can, and then runs
-`diesel database setup`.
-
-## `diesel migration`
-#### `migration generate`
-Takes the name of your migration as an argument, and will create a migration
-directory with `migrations/` in the format of
-`migrations/{current_timestamp}_{migration_name}`.  It will also generate
-`up.sql` and `down.sql` files, for running your migration up and down
-respectively.
-
-#### `migration run`
-Runs all pending migrations, as determined by diesel's internal schema table.
-
-#### `migration revert`
-Runs the `down.sql` for the most recent migration.
-
-#### `migration redo`
-Runs the `down.sql` and then the `up.sql` for the most recent migration.
-
-## `diesel print-schema`
-Prints table definitions for database schema.
-
-[pending-migrations]: https://docs.rs/diesel_migrations/*/diesel_migrations/fn.run_pending_migrations.html
-[rust-dotenv]: https://github.com/dotenv-rs/dotenv#examples
-
-
-Bash completion
----------------
-
-Diesel can generate a bash completion script for itself:
-
-#### linux
-
-```sh
-$ diesel completions bash > /etc/bash_completion.d/diesel
-```
-
-
-#### os x (homebrew)
-
-```sh
-$ brew install bash-completion  # you may already have this installed
-$ diesel completions bash > $(brew --prefix)/etc/bash_completion.d/diesel
-```
+The script includes recovery logic (revert/run, reset, retry once). If it still
+fails, fix the migration SQL first, then rerun the script.

--- a/backend/scripts/run_migrations_update_schema.sh
+++ b/backend/scripts/run_migrations_update_schema.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(git -C "${BACKEND_DIR}" rev-parse --show-toplevel)"
+REPO_PREFIX="$(git -C "${BACKEND_DIR}" rev-parse --show-prefix)"
+
+SCHEMA_REL="src/schema.rs"
+PATCH_REL="src/schema.patch"
+SCHEMA_PATH="${BACKEND_DIR}/${SCHEMA_REL}"
+PATCH_PATH="${BACKEND_DIR}/${PATCH_REL}"
+REPO_SCHEMA_REL="${REPO_PREFIX}${SCHEMA_REL}"
+
+if ! command -v diesel >/dev/null 2>&1; then
+    echo "Error: diesel CLI not found in PATH." >&2
+    exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git not found in PATH." >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+BASE_SCHEMA="${TMP_DIR}/schema.base.rs"
+NEW_PATCH="${TMP_DIR}/schema.new.patch"
+TMP_INDEX="${TMP_DIR}/index"
+
+cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+pushd "${BACKEND_DIR}" >/dev/null
+
+: > "${PATCH_PATH}"
+
+run_migrations() {
+    diesel migration revert --all && diesel migration run
+}
+
+if ! run_migrations; then
+    echo "Migration sequence failed. Resetting database and retrying once..." >&2
+    rm -f "${BACKEND_DIR}/data/diesel.sqlite" "${BACKEND_DIR}/data/diesel.sqlite-shm" "${BACKEND_DIR}/data/diesel.sqlite-wal"
+    if ! diesel database reset; then
+        echo "Error: database reset failed; aborting with empty ${PATCH_REL}." >&2
+        exit 1
+    fi
+fi
+
+cp "${SCHEMA_PATH}" "${BASE_SCHEMA}"
+
+perl -0pi -e 's/\bTimestamp\b/TimestamptzSqlite/g' "${SCHEMA_PATH}"
+
+BASE_BLOB="$(git hash-object -w "${BASE_SCHEMA}")"
+
+GIT_INDEX_FILE="${TMP_INDEX}" git -C "${REPO_ROOT}" read-tree --empty
+GIT_INDEX_FILE="${TMP_INDEX}" git -C "${REPO_ROOT}" update-index \
+    --add \
+    --cacheinfo 100644,"${BASE_BLOB}","${REPO_SCHEMA_REL}"
+
+set +e
+GIT_INDEX_FILE="${TMP_INDEX}" git -C "${REPO_ROOT}" diff -U6 -- "${REPO_SCHEMA_REL}" > "${NEW_PATCH}"
+DIFF_STATUS=$?
+set -e
+
+if [[ ${DIFF_STATUS} -gt 1 ]]; then
+    echo "Error: failed to generate ${PATCH_REL} diff." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname -- "${PATCH_PATH}")"
+cp "${NEW_PATCH}" "${PATCH_PATH}"
+
+if [[ ! -s "${PATCH_PATH}" ]]; then
+    echo "No schema changes needed; wrote empty ${PATCH_REL}."
+else
+    echo "Updated ${PATCH_REL} from current ${SCHEMA_REL}."
+fi
+
+popd >/dev/null

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -79,11 +79,11 @@ struct JwtClaims {
 impl Session {
     // This includes any form of expiry which can happen to this session
     pub fn access_expiry(&self) -> DateTime<Utc> {
-        (self.refreshed_at() + SESSION_ACCESS_EXPIRY).min(self.login_expiry())
+        (self.refreshed_at + SESSION_ACCESS_EXPIRY).min(self.login_expiry())
     }
 
     pub fn login_expiry(&self) -> DateTime<Utc> {
-        (self.refreshed_at() + SESSION_LOGIN_EXPIRY_ROLLING)
-            .min(self.last_authenticated_at() + SESSION_LOGIN_EXPIRY)
+        (self.refreshed_at + SESSION_LOGIN_EXPIRY_ROLLING)
+            .min(self.last_authenticated_at + SESSION_LOGIN_EXPIRY)
     }
 }

--- a/backend/src/auth/two_factor.rs
+++ b/backend/src/auth/two_factor.rs
@@ -248,7 +248,7 @@ pub fn consume_recovery_code(
 ) -> AppResult<bool> {
     use crate::schema::two_fa_recovery_codes::dsl::*;
 
-    let now = chrono::Utc::now().naive_utc();
+    let now = chrono::Utc::now();
     let hash = hash_recovery_code(code_plain);
 
     let updated = diesel::update(

--- a/backend/src/auth/user.rs
+++ b/backend/src/auth/user.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
 
+use chrono::DateTime;
+use chrono::Utc;
+
 use super::two_factor;
 use super::util;
 use crate::auth::TwoFactorError;
@@ -226,10 +229,10 @@ pub struct SessionInfo {
     pub user_id: i32,
     pub device_name: Option<String>,
     pub ip_address: Option<String>,
-    pub created_at: chrono::NaiveDateTime,
-    pub last_used_at: chrono::NaiveDateTime,
-    pub access_expiry: chrono::NaiveDateTime,
-    pub login_expiry: chrono::NaiveDateTime,
+    pub created_at: DateTime<Utc>,
+    pub last_used_at: DateTime<Utc>,
+    pub access_expiry: DateTime<Utc>,
+    pub login_expiry: DateTime<Utc>,
 }
 
 impl From<&Session> for SessionInfo {
@@ -239,10 +242,10 @@ impl From<&Session> for SessionInfo {
             user_id: session.user_id,
             device_name: session.device_name.clone(),
             ip_address: session.ip_address.clone(),
-            created_at: session.created_at().naive_utc(),
-            last_used_at: session.last_used_at().naive_utc(),
-            access_expiry: session.access_expiry().naive_utc(),
-            login_expiry: session.login_expiry().naive_utc(),
+            created_at: session.created_at,
+            last_used_at: session.last_used_at,
+            access_expiry: session.access_expiry(),
+            login_expiry: session.login_expiry(),
         }
     }
 }
@@ -368,7 +371,7 @@ fn deauth_other_sessions(
 
 fn deauth_sessions(conn: &mut DbConn, target_user: i32, session_ids: &[i32]) -> AppResult<usize> {
     use crate::schema::sessions::dsl::*;
-    let epoch = chrono::DateTime::UNIX_EPOCH.naive_utc();
+    let epoch = chrono::DateTime::UNIX_EPOCH;
     let result = diesel::update(
         sessions
             .filter(user_id.eq(target_user))
@@ -441,7 +444,7 @@ async fn two_fa_start(
                 diesel::update(users.filter(id.eq(user.id)).filter(totp_enabled.eq(false)))
                     .set((
                         totp_secret_enc.eq(Some(secret_enc)),
-                        totp_confirmed_at.eq::<Option<chrono::NaiveDateTime>>(None),
+                        totp_confirmed_at.eq::<Option<DateTime<Utc>>>(None),
                     ))
                     .execute(conn)?;
 
@@ -511,7 +514,7 @@ async fn two_fa_confirm(
             }
 
             let recovery_codes = conn.transaction::<_, ApiError, _>(|conn| {
-                let now = chrono::Utc::now().naive_utc();
+                let now = chrono::Utc::now();
                 let updated = diesel::update(
                     users
                         .filter(id.eq(user.id))
@@ -580,7 +583,7 @@ async fn two_fa_disable(
             .set((
                 totp_enabled.eq(false),
                 totp_secret_enc.eq::<Option<String>>(None),
-                totp_confirmed_at.eq::<Option<chrono::NaiveDateTime>>(None),
+                totp_confirmed_at.eq::<Option<DateTime<Utc>>>(None),
             ))
             .execute(conn)?;
 

--- a/backend/src/auth/util.rs
+++ b/backend/src/auth/util.rs
@@ -91,7 +91,7 @@ pub fn jwt_create(session: &Session, jti: SessionTokenHashTruncated) -> AppResul
         sid: session.id,
         jti,
         exp: session.access_expiry().timestamp() as usize,
-        iat: session.refreshed_at().timestamp() as usize,
+        iat: session.refreshed_at.timestamp() as usize,
     };
     Ok(jsonwebtoken::encode(
         &jsonwebtoken::Header::default(),

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,5 +1,17 @@
+//! Database models used by the backend.
+//!
+//! These structs are mapped to Diesel tables declared in `crate::schema`.
+//! The schema file is generated from migrations and then customized via
+//! `src/schema.patch`.
+//!
+//! When changing anything related to database migrations, run:
+//! `backend/scripts/run_migrations_update_schema.sh`
+//!
+//! This applies migrations to the local database and regenerates `src/schema.rs`
+//! (and the corresponding patch workflow) so models and schema stay in sync.
+
 use crate::{auth::session_token::SessionTokenHash, models::nickname::Nickname};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use diesel_autoincrement_new_struct::{NewInsertable, apply};
 use salvo::oapi::ToSchema;
@@ -23,19 +35,10 @@ pub struct User {
     pub totp_enabled: bool,
     #[serde(skip)]
     pub totp_secret_enc: Option<String>,
-    totp_confirmed_at: Option<NaiveDateTime>,
+    pub totp_confirmed_at: Option<DateTime<Utc>>,
     #[serde(skip)]
     pub password_hash: String,
-    created_at: NaiveDateTime,
-}
-
-impl User {
-    pub fn totp_confirmed_at(&self) -> Option<DateTime<Utc>> {
-        self.totp_confirmed_at.map(|dt| dt.and_utc())
-    }
-    pub fn created_at(&self) -> DateTime<Utc> {
-        self.created_at.and_utc()
-    }
+    pub created_at: DateTime<Utc>,
 }
 
 impl NewUser {
@@ -47,7 +50,7 @@ impl NewUser {
             totp_secret_enc: None,
             totp_confirmed_at: None,
             password_hash,
-            created_at: chrono::Utc::now().naive_utc(),
+            created_at: chrono::Utc::now(),
         }
     }
 }
@@ -64,25 +67,10 @@ pub struct Session {
     pub device_id: String,
     pub device_name: Option<String>,
     pub ip_address: Option<String>,
-    created_at: NaiveDateTime,
-    refreshed_at: NaiveDateTime,
-    last_used_at: NaiveDateTime,
-    last_authenticated_at: NaiveDateTime,
-}
-
-impl Session {
-    pub fn created_at(&self) -> DateTime<Utc> {
-        self.created_at.and_utc()
-    }
-    pub fn refreshed_at(&self) -> DateTime<Utc> {
-        self.refreshed_at.and_utc()
-    }
-    pub fn last_used_at(&self) -> DateTime<Utc> {
-        self.last_used_at.and_utc()
-    }
-    pub fn last_authenticated_at(&self) -> DateTime<Utc> {
-        self.last_authenticated_at.and_utc()
-    }
+    pub created_at: DateTime<Utc>,
+    pub refreshed_at: DateTime<Utc>,
+    pub last_used_at: DateTime<Utc>,
+    pub last_authenticated_at: DateTime<Utc>,
 }
 
 #[apply(NewInsertable!)]
@@ -94,17 +82,8 @@ pub struct TwoFaRecoveryCode {
     pub id: i32,
     pub user_id: i32,
     pub code_hash: Vec<u8>,
-    used_at: Option<NaiveDateTime>,
-    created_at: NaiveDateTime,
-}
-
-impl TwoFaRecoveryCode {
-    pub fn used_at(&self) -> Option<DateTime<Utc>> {
-        self.used_at.map(|dt| dt.and_utc())
-    }
-    pub fn created_at(&self) -> DateTime<Utc> {
-        self.created_at.and_utc()
-    }
+    pub used_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
 }
 
 impl NewTwoFaRecoveryCode {
@@ -113,7 +92,7 @@ impl NewTwoFaRecoveryCode {
             user_id,
             code_hash,
             used_at: None,
-            created_at: chrono::Utc::now().naive_utc(),
+            created_at: chrono::Utc::now(),
         }
     }
 }
@@ -126,7 +105,7 @@ impl Session {
         device_name: Option<String>,
         ip_address: Option<String>,
     ) -> Self {
-        let now = chrono::Utc::now().naive_utc();
+        let now = chrono::Utc::now();
 
         Self {
             id: self.id,
@@ -154,7 +133,7 @@ impl NewSession {
         device_name: Option<String>,
         ip_address: Option<String>,
     ) -> Self {
-        let now = chrono::Utc::now().naive_utc();
+        let now = chrono::Utc::now();
         Self {
             user_id,
             token_hash,
@@ -176,7 +155,7 @@ impl NewSession {
 pub struct AvatarLarge {
     pub user_id: i32,
     pub data: Vec<u8>,
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl AvatarLarge {
@@ -184,12 +163,8 @@ impl AvatarLarge {
         Self {
             user_id,
             data,
-            updated_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now(),
         }
-    }
-
-    pub fn updated_at(&self) -> DateTime<Utc> {
-        self.updated_at.and_utc()
     }
 }
 
@@ -200,7 +175,7 @@ impl AvatarLarge {
 pub struct AvatarSmall {
     pub user_id: i32,
     pub data: Vec<u8>,
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl AvatarSmall {
@@ -208,11 +183,7 @@ impl AvatarSmall {
         Self {
             user_id,
             data,
-            updated_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now(),
         }
-    }
-
-    pub fn updated_at(&self) -> DateTime<Utc> {
-        self.updated_at.and_utc()
     }
 }

--- a/backend/src/routers/users.rs
+++ b/backend/src/routers/users.rs
@@ -3,6 +3,8 @@
 //! With this you can query users by ID or nickname.
 //!
 
+use chrono::{DateTime, Utc};
+
 use crate::models::nickname::Nickname;
 use crate::prelude::*;
 use crate::{models::User, stream::StreamManager};
@@ -32,17 +34,16 @@ pub fn router(path: &str) -> Router {
 pub struct PublicUser {
     pub id: i32,
     pub nickname: Nickname,
-    pub created_at: chrono::NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     pub online: bool,
 }
 
 impl From<User> for PublicUser {
     fn from(user: User) -> Self {
-        let created_at = user.created_at().naive_utc();
         Self {
             id: user.id,
             nickname: user.nickname,
-            created_at,
+            created_at: user.created_at,
             online: StreamManager::global().is_connected(user.id),
         }
     }

--- a/backend/src/schema.patch
+++ b/backend/src/schema.patch
@@ -1,0 +1,74 @@
+diff --git a/backend/src/schema.rs b/backend/src/schema.rs
+index a2c7e97..5b5f665 100644
+--- a/backend/src/schema.rs
++++ b/backend/src/schema.rs
+@@ -1,59 +1,59 @@
+ // @generated automatically by Diesel CLI.
+ 
+ diesel::table! {
+     avatars_large (user_id) {
+         user_id -> Integer,
+         data -> Binary,
+-        updated_at -> Timestamp,
++        updated_at -> TimestamptzSqlite,
+     }
+ }
+ 
+ diesel::table! {
+     avatars_small (user_id) {
+         user_id -> Integer,
+         data -> Binary,
+-        updated_at -> Timestamp,
++        updated_at -> TimestamptzSqlite,
+     }
+ }
+ 
+ diesel::table! {
+     sessions (id) {
+         id -> Integer,
+         user_id -> Integer,
+         token_hash -> Binary,
+         device_id -> Text,
+         device_name -> Nullable<Text>,
+         ip_address -> Nullable<Text>,
+-        created_at -> Timestamp,
+-        refreshed_at -> Timestamp,
+-        last_used_at -> Timestamp,
+-        last_authenticated_at -> Timestamp,
++        created_at -> TimestamptzSqlite,
++        refreshed_at -> TimestamptzSqlite,
++        last_used_at -> TimestamptzSqlite,
++        last_authenticated_at -> TimestamptzSqlite,
+     }
+ }
+ 
+ diesel::table! {
+     two_fa_recovery_codes (id) {
+         id -> Integer,
+         user_id -> Integer,
+         code_hash -> Binary,
+-        used_at -> Nullable<Timestamp>,
+-        created_at -> Timestamp,
++        used_at -> Nullable<TimestamptzSqlite>,
++        created_at -> TimestamptzSqlite,
+     }
+ }
+ 
+ diesel::table! {
+     users (id) {
+         id -> Integer,
+         email -> Text,
+         nickname -> Text,
+         totp_enabled -> Bool,
+         totp_secret_enc -> Nullable<Text>,
+-        totp_confirmed_at -> Nullable<Timestamp>,
++        totp_confirmed_at -> Nullable<TimestamptzSqlite>,
+         password_hash -> Text,
+-        created_at -> Timestamp,
++        created_at -> TimestamptzSqlite,
+     }
+ }
+ 
+ diesel::joinable!(avatars_large -> users (user_id));
+ diesel::joinable!(avatars_small -> users (user_id));
+ diesel::joinable!(sessions -> users (user_id));

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -4,7 +4,7 @@ diesel::table! {
     avatars_large (user_id) {
         user_id -> Integer,
         data -> Binary,
-        updated_at -> Timestamp,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -12,7 +12,7 @@ diesel::table! {
     avatars_small (user_id) {
         user_id -> Integer,
         data -> Binary,
-        updated_at -> Timestamp,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -24,10 +24,10 @@ diesel::table! {
         device_id -> Text,
         device_name -> Nullable<Text>,
         ip_address -> Nullable<Text>,
-        created_at -> Timestamp,
-        refreshed_at -> Timestamp,
-        last_used_at -> Timestamp,
-        last_authenticated_at -> Timestamp,
+        created_at -> TimestamptzSqlite,
+        refreshed_at -> TimestamptzSqlite,
+        last_used_at -> TimestamptzSqlite,
+        last_authenticated_at -> TimestamptzSqlite,
     }
 }
 
@@ -36,8 +36,8 @@ diesel::table! {
         id -> Integer,
         user_id -> Integer,
         code_hash -> Binary,
-        used_at -> Nullable<Timestamp>,
-        created_at -> Timestamp,
+        used_at -> Nullable<TimestamptzSqlite>,
+        created_at -> TimestamptzSqlite,
     }
 }
 
@@ -48,9 +48,9 @@ diesel::table! {
         nickname -> Text,
         totp_enabled -> Bool,
         totp_secret_enc -> Nullable<Text>,
-        totp_confirmed_at -> Nullable<Timestamp>,
+        totp_confirmed_at -> Nullable<TimestamptzSqlite>,
         password_hash -> Text,
-        created_at -> Timestamp,
+        created_at -> TimestamptzSqlite,
     }
 }
 


### PR DESCRIPTION
Closes #51

For now, this includes the changes of the PR #55, so merging that first and then rabasing this PR will give the slimmed down delta.

Note the correct displaying of the jwt expiry timestamp:
---
<img width="1042" height="1482" alt="image" src="https://github.com/user-attachments/assets/29f771c9-409b-4d6d-941f-2c1e80903f05" />
