### PR TITLE
Feat/combat system

### DIFF
--- a/backend/src/game/ffi.rs
+++ b/backend/src/game/ffi.rs
@@ -45,8 +45,8 @@ extern "C" {
     fn game_remove_player(game: RawGameHandle, player_id: u32) -> bool;
     fn game_get_player_count(game: RawGameHandle) -> usize;
 
-    // Entity management
-    fn game_create_projectile(
+     // Entity management
+/*    fn game_create_projectile(
         game: RawGameHandle,
         entity_id: u32,
         pos_x: f32,
@@ -113,7 +113,7 @@ extern "C" {
         y: f32,
         z: f32,
     ) -> bool;
-
+ */
     // Input handling
     fn game_set_input(
         game: RawGameHandle,
@@ -232,7 +232,7 @@ impl GameHandle {
     pub fn get_player_count(&self) -> usize {
         unsafe { game_get_player_count(self.0) }
     }
-
+/*
     pub fn create_projectile(
         &mut self,
         entity_id: u32,
@@ -328,7 +328,7 @@ impl GameHandle {
     pub fn set_entity_velocity(&mut self, entity_id: u32, velocity: Vector3D) -> bool {
         unsafe { game_set_entity_velocity(self.0, entity_id, velocity.x, velocity.y, velocity.z) }
     }
-
+ */
     pub fn set_input(
         &mut self,
         player_id: u32,

--- a/backend/src/game/ffi.rs
+++ b/backend/src/game/ffi.rs
@@ -137,8 +137,6 @@ extern "C" {
     fn game_get_frame_number(game: RawGameHandle) -> u64;
     fn game_get_game_time(game: RawGameHandle) -> f64;
 
-    // Combat
-    fn game_register_hit(game: RawGameHandle, attacker_id: u32, victim_id: u32, damage: f32);
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
@@ -390,10 +388,6 @@ impl GameHandle {
 
     pub fn get_game_time(&self) -> f64 {
         unsafe { game_get_game_time(self.0) }
-    }
-
-    pub fn register_hit(&mut self, attacker_id: u32, victim_id: u32, damage: f32) {
-        unsafe { game_register_hit(self.0, attacker_id, victim_id, damage) }
     }
 
     /// Minimum number of players required to start a game.

--- a/backend/src/game/game.rs
+++ b/backend/src/game/game.rs
@@ -76,11 +76,6 @@ impl Game {
                 );
                 true
             }
-            GameClientMessage::RegisterHit { victim_id, damage } => {
-                self.lock().register_hit(player_id, victim_id, damage);
-                debug!(player_id, victim_id, damage, "Hit registered");
-                true
-            }
             GameClientMessage::Leave => false,
         }
     }

--- a/backend/src/game/messages.rs
+++ b/backend/src/game/messages.rs
@@ -40,9 +40,6 @@ pub enum GameClientMessage {
         sprinting: bool,
     },
 
-    /// Register a hit on another player (client-authoritative for now)
-    RegisterHit { victim_id: u32, damage: f32 },
-
     /// Player is leaving the game
     Leave,
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "trap 'kill 0' INT; vite",
 		"build": "tsc -b && vite build",
 		"lint": "eslint . --ext .ts,.tsx --fix",
 		"typecheck": "tsc --noEmit",

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -388,8 +388,21 @@ class GameClient {
 		);
 		if (this.jumpState !== JumpState.GROUNDED) return;
 
-		if (input.isAttacking) {
-			this.playAnimation('attack', true);
+		const attackAnim = this.localCharacter.animations.get(AnimationNames.attack);
+		const isAttackPlaying = attackAnim?.isPlaying ?? false;
+
+		// Reset state tracker when attack animation finishes naturally so it can replay
+		if (this.currentAnimState === 'attack' && !isAttackPlaying) {
+			this.currentAnimState = '';
+		}
+
+		if (isAttackPlaying && isMoving) {
+			// Movement cancels the attack animation
+			this.playAnimation(input.isSprinting ? 'run' : 'walk');
+		} else if (isAttackPlaying) {
+			// Attack animation is playing — let it finish, pressing attack again keeps it going
+		} else if (input.isAttacking) {
+			this.playAnimation('attack', false); // non-looped: play once to completion
 		} else if (isMoving) {
 			this.playAnimation(input.isSprinting ? 'run' : 'walk');
 		} else {
@@ -577,8 +590,14 @@ export default function SimpleGameClient({
 			const keysPressed = new Set<string>();
 
 			scene.onKeyboardObservable.add((kbInfo) => {
-				if (kbInfo.type === 1) keysPressed.add(kbInfo.event.key.toLowerCase());
-				else if (kbInfo.type === 2) keysPressed.delete(kbInfo.event.key.toLowerCase());
+				if (kbInfo.type === 1) {
+					keysPressed.add(kbInfo.event.key.toLowerCase());
+					// Attack is a one-shot trigger (keydown only, ignore keyboard repeat)
+					if (kbInfo.event.key.toLowerCase() === 'e' && !kbInfo.event.repeat)
+						input.isAttacking = true;
+				} else if (kbInfo.type === 2) {
+					keysPressed.delete(kbInfo.event.key.toLowerCase());
+				}
 			});
 
 			// Precomputed isometric directions (camera rotated 45° around Y)
@@ -612,11 +631,10 @@ export default function SimpleGameClient({
 				input.movementDirection.x = dir[0];
 				input.movementDirection.z = dir[1];
 				input.isJumping = keysPressed.has(' ');
-				input.isAttacking = keysPressed.has('e');
-				input.isSprinting = keysPressed.has('shift'); // Hold Shift to sprint
+				input.isSprinting = keysPressed.has('shift');
 
-				// Update animations based on input
 				gameClient.updateLocalAnimation(input);
+				input.isAttacking = false; // clear one-shot trigger after processing
 			});
 
 			// Track last movement direction so character keeps facing that way when idle

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -119,6 +119,9 @@ class GameClient {
 	private remoteJumpStates: Map<number, JumpState> = new Map();
 	private characterConfig: CharacterConfig;
 	private characterClassesRef: RefObject<Map<number, string>>;
+	private gui: any = null;
+	private enemyBars: Map<number, { bg: any; fill: any }> = new Map();
+	private localHealthFill: any = null;
 
 	constructor(
 		scene: Scene,
@@ -132,6 +135,75 @@ class GameClient {
 		this.camera = camera;
 		this.characterConfig = characterConfig;
 		this.characterClassesRef = characterClassesRef;
+		this.setupHUD();
+	}
+
+	private setupHUD(): void {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const GUI = (BABYLON as any).GUI;
+		this.gui = GUI.AdvancedDynamicTexture.CreateFullscreenUI('HUD', true, this.scene);
+
+		// Update enemy bar positions every frame by projecting world-space position
+		this.scene.onBeforeRenderObservable.add(() => {
+			for (const [playerID, bar] of this.enemyBars.entries()) {
+				const char = this.characters.get(playerID);
+				if (!char) continue;
+				const pos = char.rootNode.getAbsolutePosition();
+				bar.bg.moveToVector3(new BABYLON.Vector3(pos.x, pos.y + 2.4, pos.z), this.scene);
+			}
+		});
+
+		// Local player health bar — bottom center
+		const localBg = new GUI.Rectangle('local-hp-bg');
+		localBg.width = '200px';
+		localBg.height = '14px';
+		localBg.cornerRadius = 3;
+		localBg.color = '#00000099';
+		localBg.thickness = 1;
+		localBg.background = '#1a1a1a';
+		localBg.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_CENTER;
+		localBg.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
+		localBg.top = '-28px';
+		this.gui.addControl(localBg);
+
+		const localFill = new GUI.Rectangle('local-hp-fill');
+		localFill.width = '100%';
+		localFill.height = '100%';
+		localFill.cornerRadius = 0;
+		localFill.color = 'transparent';
+		localFill.thickness = 0;
+		localFill.background = '#c0392b';
+		localFill.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+		localBg.addControl(localFill);
+
+		this.localHealthFill = localFill;
+	}
+
+	private createEnemyBar(playerID: number): void {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const GUI = (BABYLON as any).GUI;
+
+		const bg = new GUI.Rectangle(`enemy-hp-bg-${playerID}`);
+		bg.width = '54px';
+		bg.height = '5px';
+		bg.cornerRadius = 2;
+		bg.color = 'transparent';
+		bg.thickness = 0;
+		bg.background = '#1a1a1a';
+		bg.isPointerBlocker = false;
+		this.gui.addControl(bg);
+
+		const fill = new GUI.Rectangle(`enemy-hp-fill-${playerID}`);
+		fill.width = '100%';
+		fill.height = '100%';
+		fill.cornerRadius = 0;
+		fill.color = 'transparent';
+		fill.thickness = 0;
+		fill.background = '#c0392b';
+		fill.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+		bg.addControl(fill);
+
+		this.enemyBars.set(playerID, { bg, fill });
 	}
 
 	async initLocalPlayer(): Promise<void> {
@@ -173,6 +245,11 @@ class GameClient {
 					this.localCharacter.setRotation(char.yaw);
 				}
 
+				if (this.localHealthFill) {
+					const pct = char.max_health > 0 ? char.health / char.max_health : 0;
+					this.localHealthFill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
+				}
+
 				// Update camera to follow player
 				this.camera.position = new BABYLON.Vector3(
 					this.position.x + ISO_CAM_OFFSET.x,
@@ -193,6 +270,12 @@ class GameClient {
 					remoteChar.setPosition(pos);
 					remoteChar.setRotation(char.yaw);
 					this.updateRemoteAnimation(char.player_id, remoteChar, char);
+
+					const bar = this.enemyBars.get(char.player_id);
+					if (bar) {
+						const pct = char.max_health > 0 ? char.health / char.max_health : 0;
+						bar.fill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
+					}
 				}
 			}
 		}
@@ -208,6 +291,11 @@ class GameClient {
 			this.characters.delete(playerID);
 			this.loadingCharacters.delete(playerID);
 			this.remoteJumpStates.delete(playerID);
+			const bar = this.enemyBars.get(playerID);
+			if (bar) {
+				bar.bg.dispose();
+				this.enemyBars.delete(playerID);
+			}
 		}
 	}
 
@@ -236,6 +324,7 @@ class GameClient {
 			this.characters.set(playerID, remoteChar);
 			this.remoteJumpStates.set(playerID, JumpState.GROUNDED);
 			remoteChar.playAnimation(AnimationNames.idle, true);
+			this.createEnemyBar(playerID);
 		} catch (error) {
 			console.error(`Failed to load remote character ${playerID}:`, error);
 		} finally {

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -451,6 +451,8 @@ export default function SimpleGameClient({
 		canvas.tabIndex = 1;
 		const onFocus = () => canvas.focus();
 		window.addEventListener('focus', onFocus);
+		let onKeydown: ((event: KeyboardEvent) => void) | null = null;
+		let onResize: (() => void) | null = null;
 
 		(async () => {
 			const engine = new BABYLON.Engine(canvas, true);
@@ -550,7 +552,7 @@ export default function SimpleGameClient({
 
 			// Enable Inspector with Ctrl+Shift+I
 			let inspectorLoaded = false;
-			window.addEventListener('keydown', async (event) => {
+			onKeydown = async (event: KeyboardEvent) => {
 				if (event.ctrlKey && event.shiftKey && event.key === 'I') {
 					event.preventDefault();
 					if (!inspectorLoaded) {
@@ -567,7 +569,8 @@ export default function SimpleGameClient({
 						});
 					}
 				}
-			});
+			};
+			window.addEventListener('keydown', onKeydown);
 
 			const gameClient = new GameClient(
 				scene,
@@ -694,19 +697,23 @@ export default function SimpleGameClient({
 				scene.render();
 			});
 
-			window.addEventListener('resize', () => {
+			onResize = () => {
 				engine.resize();
 				const a = engine.getRenderWidth() / engine.getRenderHeight();
 				camera.orthoLeft = -ISO_ORTHO_SIZE * a;
 				camera.orthoRight = ISO_ORTHO_SIZE * a;
 				camera.orthoTop = ISO_ORTHO_SIZE;
 				camera.orthoBottom = -ISO_ORTHO_SIZE;
-			});
+			};
+			window.addEventListener('resize', onResize);
 		})();
 
 		return () => {
-			window.removeEventListener('focus', onFocus);
 			disposed = true;
+			window.removeEventListener('focus', onFocus);
+			if (onKeydown) window.removeEventListener('keydown', onKeydown);
+			if (onResize) window.removeEventListener('resize', onResize);
+			gameClientRef.current = null;
 			engineRef.current?.stopRenderLoop();
 			sceneInstance?.dispose();
 			engineRef.current?.dispose();

--- a/frontend/src/game/AnimatedCharacter.ts
+++ b/frontend/src/game/AnimatedCharacter.ts
@@ -81,7 +81,7 @@ export class AnimatedCharacter {
 	}
 
 	playAnimation(name: string, loop: boolean = true): void {
-		if (this.currentAnimationName === name) return;
+		if (this.currentAnimationName === name && this.currentAnimation?.isPlaying) return;
 		const anim = this.animations.get(name);
 		if (!anim) {
 			console.warn(`[playAnimation] "${name}" not found. Available:`, [

--- a/game_engine/include/ArenaGame.hpp
+++ b/game_engine/include/ArenaGame.hpp
@@ -2,6 +2,7 @@
 
 #include "Core/World.hpp"
 #include "GameTypes.hpp"
+#include "Presets.hpp"
 #include <vector>
 #include <chrono>
 #include <cmath>
@@ -80,9 +81,6 @@ public:
     uint64_t getFrameNumber() const { return m_frameNumber; }
     double getGameTime() const { return m_gameTime; }
     size_t getPlayerCount() const { return m_world.getPlayerCount(); }
-
-    // Combat
-    void registerHit(PlayerID attackerID, PlayerID victimID, float damage);
 
     // World access (for advanced usage)
     Core::World& getWorld() { return m_world; }
@@ -191,7 +189,7 @@ inline bool ArenaGame::addPlayer(PlayerID playerID, const std::string& name) {
     Vector3D spawnPos = getSpawnPosition();
 
     // Create player entity through World
-    entt::entity entity = m_world.createPlayer(playerID, name, spawnPos);
+    entt::entity entity = m_world.createPlayer(playerID, name, spawnPos, Presets::KNIGHT);
 
     if (entity != entt::null) {
         // Face the arena centre (origin): yaw = atan2(-x, -z) for convention yaw=0 → +Z
@@ -256,11 +254,6 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
     });
 
     return snapshot;
-}
-
-inline void ArenaGame::registerHit(PlayerID attackerID, PlayerID victimID, float damage) {
-    // Delegate to World (which delegates to CombatSystem)
-    m_world.registerHit(attackerID, victimID, damage);
 }
 
 inline void ArenaGame::initializeSpawnPositions(int numPlayers) {

--- a/game_engine/include/ArenaGame.hpp
+++ b/game_engine/include/ArenaGame.hpp
@@ -72,10 +72,6 @@ public:
     bool addPlayer(PlayerID playerID, const std::string& name);
     bool removePlayer(PlayerID playerID);
 
-    // Direct entity access (returns entt::entity)
-    entt::entity getEntity(PlayerID playerID) { return m_world.getEntity(playerID); }
-    entt::entity getEntity(PlayerID playerID) const { return m_world.getEntity(playerID); }
-
     // Input handling
     void setPlayerInput(PlayerID playerID, const InputState& input);
 
@@ -93,7 +89,7 @@ public:
     const Core::World& getWorld() const { return m_world; }
 
 private:
-    // World manages all entities and systems (EnTT version)
+    // World manages all entities and systems
     Core::World m_world;
 
     // Game state (identical to ArenaGame)
@@ -195,7 +191,7 @@ inline bool ArenaGame::addPlayer(PlayerID playerID, const std::string& name) {
     Vector3D spawnPos = getSpawnPosition();
 
     // Create player entity through World
-    entt::entity entity = m_world.addPlayer(playerID, name, spawnPos);
+    entt::entity entity = m_world.createPlayer(playerID, name, spawnPos);
 
     if (entity != entt::null) {
         // Face the arena centre (origin): yaw = atan2(-x, -z) for convention yaw=0 → +Z
@@ -211,7 +207,6 @@ inline bool ArenaGame::removePlayer(PlayerID playerID) {
 }
 
 inline void ArenaGame::setPlayerInput(PlayerID playerID, const InputState& input) {
-    // Delegate to World
     m_world.setPlayerInput(playerID, input);
 }
 

--- a/game_engine/include/ArenaGame.hpp
+++ b/game_engine/include/ArenaGame.hpp
@@ -216,7 +216,6 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
     snapshot.timestamp = m_gameTime;
 
     // Get all entities that represent players (have all player components)
-    // Using EnTT view for efficient iteration
     auto& registry = const_cast<Core::World&>(m_world).getRegistry();
 
     // View of all entities with player components
@@ -229,14 +228,17 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
     >();
 
     // Convert entities to character snapshots
-    // Use view.each() for better C++20 compatibility
-    view.each([&](auto entity,
-                  Components::PlayerInfo& playerInfo,
+    view.each([&](Components::PlayerInfo& playerInfo,
                   Components::Transform& transform,
                   Components::PhysicsBody& physics,
                   Components::Health& health,
                   Components::CharacterController& controller) {
+
         // Skip dead entities
+        /**
+         * Inside a lambda, continue doesn't exist — return is used instead,
+         * which exits thecurrent lambda call and each() moves on to the next entity.
+         */
         if (!health.isAlive()) {
             return;  // continue in lambda
         }

--- a/game_engine/include/CharacterPreset.hpp
+++ b/game_engine/include/CharacterPreset.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Skills.hpp"
+#include <vector>
+
+namespace ArenaGame {
+
+	struct CharacterPreset {
+		// Health
+		float maxHealth;
+		float armor;
+
+		// CharacterController
+		float movementSpeed;
+		float rotationSpeed;
+
+		// CombatController
+		float baseDamage;
+		float damageMultiplier;
+		float criticalChance;
+		float criticalMultiplier;
+		std::vector<AttackStage> attackChain;
+		SkillDefinition skill1;
+		SkillDefinition skill2;
+	};
+};

--- a/game_engine/include/CharacterPreset.hpp
+++ b/game_engine/include/CharacterPreset.hpp
@@ -9,6 +9,7 @@ namespace ArenaGame {
 		// Health
 		float maxHealth;
 		float armor;
+		float resistance;
 
 		// CharacterController
 		float movementSpeed;

--- a/game_engine/include/Components/CharacterController.hpp
+++ b/game_engine/include/Components/CharacterController.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../GameTypes.hpp"
+#include "../CharacterPreset.hpp"
 
 namespace ArenaGame {
 namespace Components {

--- a/game_engine/include/Components/CharacterController.hpp
+++ b/game_engine/include/Components/CharacterController.hpp
@@ -128,24 +128,26 @@ struct CharacterController {
     void enableRotation() { canRotate = true; }
 
     // Static factory methods
+    static CharacterController createFromPreset(const CharacterPreset& preset) {
+        CharacterController cc;
+        cc.movementSpeed = preset.movementSpeed;
+        return cc;
+    }
     static CharacterController createDefault() {
         return CharacterController();
     }
-
     static CharacterController createFast() {
         CharacterController controller;
         controller.movementSpeed = GameConfig::CHARACTER_MOVE_SPEED * 1.5f;
         controller.jumpVelocity = GameConfig::JUMP_VELOCITY * 1.2f;
         return controller;
     }
-
     static CharacterController createSlow() {
         CharacterController controller;
         controller.movementSpeed = GameConfig::CHARACTER_MOVE_SPEED * 0.7f;
         controller.jumpVelocity = GameConfig::JUMP_VELOCITY * 0.8f;
         return controller;
     }
-
     static CharacterController createAI() {
         CharacterController controller;
         controller.canJump = false;  // AI doesn't jump by default

--- a/game_engine/include/Components/CombatController.hpp
+++ b/game_engine/include/Components/CombatController.hpp
@@ -60,6 +60,7 @@ struct CombatController {
     float chainTimer  = 0.0f;  // time elapsed since the last stage completed
     float swingTimer  = 0.0f;  // time elapsed inside the current swing
     bool  isAttacking = false; // true while swingTimer < currentStage().duration
+    bool  hitPending  = false; // hit queued at swing start, applied at swing end
 
     // ── Capability flags ─────────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ struct CombatController {
         isAttacking = true;
         swingTimer  = 0.0f;
         chainTimer  = 0.0f;  // player acted in time — reset window clock
+        hitPending  = false;
     }
 
     // Advance chain after a hit lands.

--- a/game_engine/include/Components/CombatController.hpp
+++ b/game_engine/include/Components/CombatController.hpp
@@ -1,239 +1,157 @@
 #pragma once
 
-#include "../GameTypes.hpp"
+#include "CharacterPreset.hpp"
+#include <vector>
+#include <algorithm>
+#include <cstdlib>
 
 namespace ArenaGame {
 namespace Components {
 
 // =============================================================================
-// CombatController - Attack timing, damage, and combat state
+// CombatController - Attack chain state, skills, and damage modifiers
 // =============================================================================
-// Pure data component - logic handled by CombatSystem
-// Stores combat-related state and configuration
+// Pure data component — logic handled by CombatSystem.
 //
-// Usage:
-//   CombatController combat;
-//   combat.baseDamage = 25.0f;
-//   if (combat.canAttack()) {
-//       combat.startAttack();
-//   }
+// Attack chain
+// ─────────────────────────────────────────────────────────────────────────────
+// attackChain holds the ordered sequence of AttackStages copied from the
+// CharacterPreset at entity creation.  At runtime the component tracks which
+// stage fires next (chainStage) and whether the player is still inside the
+// chain window (chainTimer).
+//
+// A normal attack fires at attackChain[chainStage].  After the swing lands,
+// advanceChain() either advances to the next stage (if chainWindow > 0) or
+// wraps back to 0 (last stage / chainWindow == 0).  If the player does not
+// press attack again before chainWindow expires, chainStage resets to 0.
+//
+// Skills
+// ─────────────────────────────────────────────────────────────────────────────
+// ability1 / ability2 are SkillDefinition slots copied from the preset.
+// Each carries its own cooldown timer ticked by updateTimers().
 // =============================================================================
 
 struct CombatController {
-    // Attack properties
-    float baseDamage;           // Base damage per attack
-    float attackRange;          // Range of melee attacks
-    float attackCooldown;       // Time between attacks (seconds)
-    float attackDuration;       // How long an attack lasts (animation time)
 
-    // Attack timing
-    float timeSinceLastAttack;  // Time since last attack started
-    float attackTimer;          // Current attack animation timer
+    // ── Preset-derived data (set once via createFromPreset) ──────────────────
 
-    // Attack state
-    bool isAttacking;           // Currently performing an attack
-    bool attackRequested;       // Player has requested an attack
+    float baseDamage;                      // base; each AttackStage multiplies this
+    std::vector<AttackStage> attackChain;  // ordered attack sequence
+    SkillDefinition ability1;
+    SkillDefinition ability2;
 
-    // Combo system (optional)
-    int comboCount;             // Current combo counter
-    float comboWindow;          // Time window to continue combo
-    float comboTimer;           // Time since last combo hit
+    // ── Damage modifiers ─────────────────────────────────────────────────────
 
-    // Damage modifiers
-    float damageMultiplier;     // Multiplier for all damage dealt (buffs/debuffs)
-    float criticalChance;       // Chance to deal critical hit (0.0-1.0)
-    float criticalMultiplier;   // Damage multiplier on critical hit
+    // Base values: set from preset, never modified at runtime.
+    // Use these to restore runtime values after a buff/debuff expires.
+    float baseDamageMultiplier;
+    float baseCriticalChance;
+    float baseCriticalMultiplier;
 
-    // Ability cooldowns
-    float ability1Cooldown;
-    float ability1Timer;
-    float ability2Cooldown;
-    float ability2Timer;
+    // Runtime values: start equal to base, modified by buffs / debuffs.
+    float damageMultiplier;
+    float criticalChance;
+    float criticalMultiplier;
 
-    // Combat capabilities
-    bool canAttack;
-    bool canUseAbilities;
+    // ── Attack chain runtime state ───────────────────────────────────────────
 
-    // Constructors
-    CombatController()
-        : baseDamage(GameConfig::MELEE_DAMAGE)
-        , attackRange(GameConfig::ATTACK_RANGE)
-        , attackCooldown(0.5f)
-        , attackDuration(0.3f)
-        , timeSinceLastAttack(999.0f)  // Can attack immediately
-        , attackTimer(0.0f)
-        , isAttacking(false)
-        , attackRequested(false)
-        , comboCount(0)
-        , comboWindow(1.0f)
-        , comboTimer(0.0f)
-        , damageMultiplier(1.0f)
-        , criticalChance(0.05f)  // 5% crit chance
-        , criticalMultiplier(2.0f)  // 2x damage on crit
-        , ability1Cooldown(5.0f)
-        , ability1Timer(0.0f)
-        , ability2Cooldown(10.0f)
-        , ability2Timer(0.0f)
-        , canAttack(true)
-        , canUseAbilities(true)
-    {}
+    int   chainStage  = 0;     // index of the stage that fires on next attack press
+    float chainTimer  = 0.0f;  // time elapsed since the last stage completed
+    float swingTimer  = 0.0f;  // time elapsed inside the current swing
+    bool  isAttacking = false; // true while swingTimer < currentStage().duration
 
-    // Attack state management
+    // ── Capability flags ─────────────────────────────────────────────────────
+
+    bool canAttack       = true;
+    bool canUseAbilities = true;
+
+    // ── Queries ──────────────────────────────────────────────────────────────
+
+    // Returns the stage that fires on the next attack input.
+    const AttackStage& currentStage() const {
+        return attackChain[chainStage];
+    }
+
+    // Ready to accept an attack input — not mid-swing and attacks are enabled.
     bool canPerformAttack() const {
-        return canAttack && !isAttacking && timeSinceLastAttack >= attackCooldown;
+        return canAttack && !isAttacking && !attackChain.empty();
     }
 
+    bool canUseAbility1() const { return canUseAbilities && ability1.canUse(); }
+    bool canUseAbility2() const { return canUseAbilities && ability2.canUse(); }
+
+    // ── State transitions (called by CombatSystem) ───────────────────────────
+
+    // Begin the current stage's swing.
     void startAttack() {
-        if (!canPerformAttack()) {
-            return;
-        }
-
         isAttacking = true;
-        attackTimer = 0.0f;
-        timeSinceLastAttack = 0.0f;
-        attackRequested = false;
+        swingTimer  = 0.0f;
+        chainTimer  = 0.0f;  // player acted in time — reset window clock
     }
 
-    void finishAttack() {
-        isAttacking = false;
-        attackTimer = 0.0f;
+    // Advance chain after a hit lands.
+    // Called by CombatSystem once per successful hit, not per frame.
+    void advanceChain() {
+        const bool lastStage = (chainStage + 1 >= static_cast<int>(attackChain.size()));
+        const bool chainEnds = lastStage || attackChain[chainStage].chainWindow <= 0.0f;
+
+        chainStage = chainEnds ? 0 : chainStage + 1;
+        chainTimer = 0.0f;
     }
 
-    void requestAttack() {
-        attackRequested = true;
-    }
+    void useAbility1() { ability1.trigger(); }
+    void useAbility2() { ability2.trigger(); }
 
-    void clearAttackRequest() {
-        attackRequested = false;
-    }
-
-    // Update timers (called by CombatSystem)
-    void updateTimers(float deltaTime) {
-        // Attack cooldown
-        timeSinceLastAttack += deltaTime;
-
-        // Attack animation
-        if (isAttacking) {
-            attackTimer += deltaTime;
-            if (attackTimer >= attackDuration) {
-                finishAttack();
-            }
-        }
-
-        // Combo timer
-        if (comboCount > 0) {
-            comboTimer += deltaTime;
-            if (comboTimer >= comboWindow) {
-                resetCombo();
-            }
-        }
-
-        // Ability cooldowns
-        if (ability1Timer > 0.0f) {
-            ability1Timer = std::max(0.0f, ability1Timer - deltaTime);
-        }
-        if (ability2Timer > 0.0f) {
-            ability2Timer = std::max(0.0f, ability2Timer - deltaTime);
-        }
-    }
-
-    // Combo system
-    void incrementCombo() {
-        comboCount++;
-        comboTimer = 0.0f;
-    }
-
-    void resetCombo() {
-        comboCount = 0;
-        comboTimer = 0.0f;
-    }
-
-    float getComboMultiplier() const {
-        // Each combo hit increases damage by 10%, up to 50%
-        return 1.0f + std::min(comboCount * 0.1f, 0.5f);
-    }
-
-    // Ability management
-    bool canUseAbility1() const {
-        return canUseAbilities && ability1Timer <= 0.0f;
-    }
-
-    bool canUseAbility2() const {
-        return canUseAbilities && ability2Timer <= 0.0f;
-    }
-
-    void useAbility1() {
-        if (canUseAbility1()) {
-            ability1Timer = ability1Cooldown;
-        }
-    }
-
-    void useAbility2() {
-        if (canUseAbility2()) {
-            ability2Timer = ability2Cooldown;
-        }
-    }
-
-    // Damage calculation
-    float calculateDamage(bool* outIsCritical = nullptr) const {
-        float damage = baseDamage * damageMultiplier;
-
-        // Apply combo multiplier
-        damage *= getComboMultiplier();
-
-        // Check for critical hit
-        bool isCritical = (static_cast<float>(rand()) / RAND_MAX) < criticalChance;
-        if (isCritical) {
-            damage *= criticalMultiplier;
-        }
-
-        if (outIsCritical) {
-            *outIsCritical = isCritical;
-        }
-
-        return damage;
-    }
-
-    // Enable/disable capabilities
-    void disableAttacks() { canAttack = false; }
-    void enableAttacks() { canAttack = true; }
-
+    void disableAttacks()   { canAttack = false; }
+    void enableAttacks()    { canAttack = true;  }
     void disableAbilities() { canUseAbilities = false; }
-    void enableAbilities() { canUseAbilities = true; }
+    void enableAbilities()  { canUseAbilities = true;  }
 
-    // Static factory methods
-    static CombatController createMelee() {
-        CombatController combat;
-        combat.baseDamage = 25.0f;
-        combat.attackRange = 2.0f;
-        combat.attackCooldown = 0.5f;
-        return combat;
+    // ── Per-frame timer update (called by CombatSystem::updateCooldowns) ─────
+
+    void updateTimers(float deltaTime) {
+        // Advance swing — clear isAttacking once duration has elapsed
+        if (isAttacking) {
+            swingTimer += deltaTime;
+            if (swingTimer >= currentStage().duration) {
+                isAttacking = false;
+                swingTimer  = 0.0f;
+            }
+        }
+
+        // Advance chain window — break chain if player is too slow
+        if (chainStage > 0) {
+            chainTimer += deltaTime;
+            const float window = attackChain[chainStage - 1].chainWindow;
+            if (chainTimer > window) {
+                chainStage = 0;
+                chainTimer = 0.0f;
+            }
+        }
+
+        // Tick skill cooldowns
+        if (ability1.timer > 0.0f)
+            ability1.timer = std::max(0.0f, ability1.timer - deltaTime);
+        if (ability2.timer > 0.0f)
+            ability2.timer = std::max(0.0f, ability2.timer - deltaTime);
     }
 
-    static CombatController createRanged() {
-        CombatController combat;
-        combat.baseDamage = 15.0f;
-        combat.attackRange = 20.0f;
-        combat.attackCooldown = 0.3f;
-        return combat;
-    }
+    // ── Factory ──────────────────────────────────────────────────────────────
 
-    static CombatController createHeavy() {
-        CombatController combat;
-        combat.baseDamage = 50.0f;
-        combat.attackRange = 2.5f;
-        combat.attackCooldown = 1.5f;  // Slower attacks
-        combat.attackDuration = 0.8f;  // Longer animation
-        return combat;
-    }
+    static CombatController createFromPreset(const CharacterPreset& p) {
+        CombatController cc;
+        cc.baseDamage  = p.baseDamage;
+        cc.attackChain = p.attackChain;
+        cc.ability1    = p.skill1;
+        cc.ability2    = p.skill2;
 
-    static CombatController createFast() {
-        CombatController combat;
-        combat.baseDamage = 10.0f;
-        combat.attackRange = 1.5f;
-        combat.attackCooldown = 0.2f;  // Very fast attacks
-        combat.attackDuration = 0.15f;
-        return combat;
+        cc.baseDamageMultiplier   = p.damageMultiplier;
+        cc.baseCriticalChance     = p.criticalChance;
+        cc.baseCriticalMultiplier = p.criticalMultiplier;
+        cc.damageMultiplier       = p.damageMultiplier;
+        cc.criticalChance         = p.criticalChance;
+        cc.criticalMultiplier     = p.criticalMultiplier;
+        return cc;
     }
 };
 

--- a/game_engine/include/Components/CombatController.hpp
+++ b/game_engine/include/Components/CombatController.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <cstdlib>
+#include <cstdio>
 
 namespace ArenaGame {
 namespace Components {
@@ -84,6 +85,9 @@ struct CombatController {
 
     // Begin the current stage's swing.
     void startAttack() {
+        fprintf(stderr, "[CHAIN] startAttack  stage=%d/%d  duration=%.2f  range=%.1f  window=%.2f\n",
+            chainStage, static_cast<int>(attackChain.size()) - 1,
+            currentStage().duration, currentStage().range, currentStage().chainWindow);
         isAttacking = true;
         swingTimer  = 0.0f;
         chainTimer  = 0.0f;  // player acted in time — reset window clock
@@ -95,8 +99,12 @@ struct CombatController {
         const bool lastStage = (chainStage + 1 >= static_cast<int>(attackChain.size()));
         const bool chainEnds = lastStage || attackChain[chainStage].chainWindow <= 0.0f;
 
+        int prevStage = chainStage;
         chainStage = chainEnds ? 0 : chainStage + 1;
         chainTimer = 0.0f;
+
+        fprintf(stderr, "[CHAIN] advanceChain  %d -> %d  %s\n",
+            prevStage, chainStage, chainEnds ? "(chain reset)" : "(chain continues)");
     }
 
     void useAbility1() { ability1.trigger(); }
@@ -137,6 +145,21 @@ struct CombatController {
     }
 
     // ── Factory ──────────────────────────────────────────────────────────────
+
+    // Default melee combatant with no attack chain (can't attack).
+    // Used for generic actors that don't need preset-driven combat.
+    static CombatController createDefault() {
+        CombatController cc;
+        cc.baseDamage             = 10.0f;
+        cc.baseDamageMultiplier   = 1.0f;
+        cc.baseCriticalChance     = 0.1f;
+        cc.baseCriticalMultiplier = 1.5f;
+        cc.damageMultiplier       = 1.0f;
+        cc.criticalChance         = 0.1f;
+        cc.criticalMultiplier     = 1.5f;
+        // attackChain intentionally empty — canPerformAttack() returns false
+        return cc;
+    }
 
     static CombatController createFromPreset(const CharacterPreset& p) {
         CombatController cc;

--- a/game_engine/include/Components/Components.hpp
+++ b/game_engine/include/Components/Components.hpp
@@ -16,19 +16,3 @@
 #include "Health.hpp"
 #include "CharacterController.hpp"
 #include "CombatController.hpp"
-
-namespace ArenaGame {
-namespace Components {
-
-// Component type enumeration (for runtime type checking if needed)
-enum class ComponentType {
-    Transform,
-    PhysicsBody,
-    Collider,
-    Health,
-    CharacterController,
-    CombatController
-};
-
-} // namespace Components
-} // namespace ArenaGame

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../GameTypes.hpp"
+#include "../CharacterPreset.hpp"
 #include <algorithm>
+#include <cstdio>
 
 namespace ArenaGame {
 namespace Components {
@@ -93,6 +95,8 @@ struct Health {
     // Health manipulation
     void takeDamage(float rawDamage, PlayerID attackerID = 0) {
         if (invulnerable || isDead) {
+            fprintf(stderr, "[HEALTH] takeDamage skipped  raw=%.2f  invulnerable=%d  isDead=%d\n",
+                rawDamage, invulnerable, isDead);
             return;
         }
 
@@ -101,6 +105,11 @@ struct Health {
 
         // Apply resistance (percentage reduction)
         float finalDamage = damageAfterArmor * (1.0f - resistance);
+
+        fprintf(stderr, "[HEALTH] takeDamage  attacker=%u  raw=%.2f  -armor(%.1f)=%.2f  -resist(%.0f%%)=%.2f  hp: %.1f -> %.1f\n",
+            attackerID, rawDamage, armor, damageAfterArmor,
+            resistance * 100.0f, finalDamage,
+            current, current - finalDamage);
 
         // Apply damage
         current -= finalDamage;

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -161,18 +161,21 @@ struct Health {
     }
 
     // Static factory methods
+    static Health createFromPreset (const CharacterPreset& preset) {
+        Health h;
+        h.maximum = preset.maxHealth;
+        h.armor = preset.armor;
+        return h;
+    }
     static Health createCharacter() {
         return Health(GameConfig::CHARACTER_MAX_HEALTH, 0.0f, 0.0f);
     }
-
     static Health createTank() {
         return Health(150.0f, 10.0f, 0.2f);  // More HP, armor, and resistance
     }
-
     static Health createGlass() {
         return Health(50.0f, 0.0f, 0.0f);  // Low HP, no protection
     }
-
     static Health createBoss() {
         return Health(500.0f, 20.0f, 0.3f);  // High HP, armor, and resistance
     }

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -168,9 +168,10 @@ struct Health {
     }
 
     // Static factory methods
-    static Health createFromPreset (const CharacterPreset& preset) {
+    static Health createFromPreset(const CharacterPreset& preset) {
         Health h;
         h.maximum = preset.maxHealth;
+        h.current = h.maximum;
         h.armor = preset.armor;
         return h;
     }

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -23,7 +23,7 @@ namespace Components {
 // Example: raw=10, armor=2, resistance=0.1 (10%)
 //   post-armor = max(0, 10 - 2) = 8
 //   final      = 8 * 0.9        = 7.2
-//
+//w
 // armor      — counters chip damage / weak attackers; ineffective vs big hits
 // resistance — scales proportionally; stays relevant regardless of damage source
 // =============================================================================

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -12,13 +12,20 @@ namespace Components {
 // =============================================================================
 // Health - Hit points and damage handling
 // =============================================================================
-// Pure data component - logic handled by CombatSystem
-// Represents an entity that can take damage and die
+// Pure data component - damage reduction applied in takeDamage().
 //
-// Usage:
-//   Health health(100.0f);
-//   health.takeDamage(25.0f);
-//   if (!health.isAlive()) { ... }
+// Damage formula (applied in order):
+//   1. raw       = baseDamage * stageMultiplier * damageMultiplier [± crit]
+//                  (calculated in CombatSystem::calculateCombatDamage)
+//   2. post-armor  = max(0, raw - armor)          flat reduction
+//   3. final       = post-armor * (1 - resistance) percentage reduction
+//
+// Example: raw=10, armor=2, resistance=0.1 (10%)
+//   post-armor = max(0, 10 - 2) = 8
+//   final      = 8 * 0.9        = 7.2
+//
+// armor      — counters chip damage / weak attackers; ineffective vs big hits
+// resistance — scales proportionally; stays relevant regardless of damage source
 // =============================================================================
 
 struct Health {
@@ -173,6 +180,7 @@ struct Health {
         h.maximum = preset.maxHealth;
         h.current = h.maximum;
         h.armor = preset.armor;
+        h.resistance = preset.resistance;
         return h;
     }
     static Health createCharacter() {

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -46,7 +46,6 @@ struct Health {
         , lastDamageAmount(0.0f)
         , lastDamageTime(0.0)
     {}
-
     explicit Health(float maxHealth)
         : current(maxHealth)
         , maximum(maxHealth)
@@ -58,7 +57,6 @@ struct Health {
         , lastDamageAmount(0.0f)
         , lastDamageTime(0.0)
     {}
-
     Health(float maxHealth, float armor, float resistance)
         : current(maxHealth)
         , maximum(maxHealth)
@@ -78,6 +76,10 @@ struct Health {
 
     bool isFullHealth() const {
         return current >= maximum;
+    }
+
+    float getCurrentHelth() const {
+        return current;
     }
 
     float getHealthPercent() const {

--- a/game_engine/include/Components/Health.hpp
+++ b/game_engine/include/Components/Health.hpp
@@ -2,6 +2,7 @@
 
 #include "../GameTypes.hpp"
 #include "../CharacterPreset.hpp"
+#include <entt/entt.hpp>
 #include <algorithm>
 #include <cstdio>
 
@@ -32,8 +33,8 @@ struct Health {
     bool invulnerable;  // If true, takes no damage
     bool isDead;        // Cached death state
 
-    // Last damage info (for combat log, kill tracking, etc.)
-    PlayerID lastAttackerID;
+    // Last damage info (for kill feed / scoreboard — translate to PlayerID at snapshot time)
+    entt::entity lastAttacker;
     float lastDamageAmount;
     double lastDamageTime;
 
@@ -44,7 +45,7 @@ struct Health {
         , resistance(0.0f)
         , invulnerable(false)
         , isDead(false)
-        , lastAttackerID(0)
+        , lastAttacker(entt::null)
         , lastDamageAmount(0.0f)
         , lastDamageTime(0.0)
     {}
@@ -55,7 +56,7 @@ struct Health {
         , resistance(0.0f)
         , invulnerable(false)
         , isDead(false)
-        , lastAttackerID(0)
+        , lastAttacker(entt::null)
         , lastDamageAmount(0.0f)
         , lastDamageTime(0.0)
     {}
@@ -66,7 +67,7 @@ struct Health {
         , resistance(resistance)
         , invulnerable(false)
         , isDead(false)
-        , lastAttackerID(0)
+        , lastAttacker(entt::null)
         , lastDamageAmount(0.0f)
         , lastDamageTime(0.0)
     {}
@@ -93,10 +94,8 @@ struct Health {
     }
 
     // Health manipulation
-    void takeDamage(float rawDamage, PlayerID attackerID = 0) {
+    void takeDamage(float rawDamage, entt::entity attacker = entt::null) {
         if (invulnerable || isDead) {
-            fprintf(stderr, "[HEALTH] takeDamage skipped  raw=%.2f  invulnerable=%d  isDead=%d\n",
-                rawDamage, invulnerable, isDead);
             return;
         }
 
@@ -106,23 +105,22 @@ struct Health {
         // Apply resistance (percentage reduction)
         float finalDamage = damageAfterArmor * (1.0f - resistance);
 
-        fprintf(stderr, "[HEALTH] takeDamage  attacker=%u  raw=%.2f  -armor(%.1f)=%.2f  -resist(%.0f%%)=%.2f  hp: %.1f -> %.1f\n",
-            attackerID, rawDamage, armor, damageAfterArmor,
+        fprintf(stderr, "[HEALTH] raw=%.2f  -armor(%.1f)=%.2f  -resist(%.0f%%)=%.2f  hp: %.1f -> %.1f\n",
+            rawDamage, armor, damageAfterArmor,
             resistance * 100.0f, finalDamage,
-            current, current - finalDamage);
+            current, std::max(0.0f, current - finalDamage));
 
         // Apply damage
         current -= finalDamage;
 
-        // Clamp to 0
         if (current <= 0.0f) {
             current = 0.0f;
             isDead = true;
         }
 
-        // Track last damage
+        // Track last damage (translate attacker entity → PlayerID at snapshot time)
         lastDamageAmount = finalDamage;
-        lastAttackerID = attackerID;
+        lastAttacker = attacker;
         // lastDamageTime should be set by CombatSystem with game time
     }
 

--- a/game_engine/include/Components/PhysicsBody.hpp
+++ b/game_engine/include/Components/PhysicsBody.hpp
@@ -106,7 +106,6 @@ struct PhysicsBody {
         body.maxSpeed = GameConfig::CHARACTER_MAX_SPEED;
         return body;
     }
-
     static PhysicsBody createProjectile() {
         PhysicsBody body;
         body.mass = 0.5f;
@@ -116,7 +115,6 @@ struct PhysicsBody {
         body.maxSpeed = 100.0f;  // Fast projectiles
         return body;
     }
-
     static PhysicsBody createStatic() {
         PhysicsBody body;
         body.isKinematic = true;

--- a/game_engine/include/Components/PlayerInfo.hpp
+++ b/game_engine/include/Components/PlayerInfo.hpp
@@ -10,11 +10,7 @@ namespace Components {
 // PlayerInfo - Player identification and metadata
 // =============================================================================
 // Pure data component - stores player ID and name
-// Used in EnTT implementation to maintain PlayerID mapping
-//
-// In the original ECS, this data was stored in the Entity class itself.
-// With EnTT, entities are just handles (uint32_t), so we need a component
-// to store the player identification data.
+// Used to maintain PlayerID mapping
 //
 // Usage:
 //   PlayerInfo playerInfo{42, "PlayerName"};

--- a/game_engine/include/Components/Tags.hpp
+++ b/game_engine/include/Components/Tags.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+namespace ArenaGame {
+
 struct PlayerTag {};
 struct ActorTag {};
 struct ProjectileTag {};
 struct WallTag {};
 struct TriggerTag {};
+
+};

--- a/game_engine/include/Components/Tags.hpp
+++ b/game_engine/include/Components/Tags.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+struct PlayerTag {};
+struct ActorTag {};
+struct ProjectileTag {};
+struct WallTag {};
+struct TriggerTag {};

--- a/game_engine/include/Core/World.hpp
+++ b/game_engine/include/Core/World.hpp
@@ -7,11 +7,14 @@
 #include "Components/Health.hpp"
 #include "Components/CharacterController.hpp"
 #include "Components/CombatController.hpp"
+#include "Components/Tags.hpp"
+
 #include "systems/SystemManager.hpp"
 #include "systems/CharacterControllerSystem.hpp"
 #include "systems/PhysicsSystem.hpp"
 #include "systems/CollisionSystem.hpp"
 #include "systems/CombatSystem.hpp"
+
 #include <entt/entt.hpp>
 #include <unordered_map>
 #include <vector>
@@ -50,20 +53,14 @@ public:
     void update(float deltaTime);        // Phase 3: Game logic, Combat
     void lateUpdate(float deltaTime);    // Phase 4: Post-processing
 
-    // Entity management - returns entt::entity instead of Entity*
-    entt::entity createEntity(PlayerID id, const std::string& name = "");
-    entt::entity createCharacter(PlayerID id, const std::string& name, const Vector3D& spawnPos);
-    entt::entity createProjectile(PlayerID id, const Vector3D& spawnPos, const Vector3D& velocity);
-    entt::entity createWall(PlayerID id, const Vector3D& position, const Vector3D& halfExtents);
-    entt::entity createTrigger(PlayerID id, const Vector3D& position, float radius);
+    // Entity management
+    entt::entity createActor(const Vector3D& spawnPos);
+    entt::entity createProjectile(const Vector3D& spawnPos, const Vector3D& velocity);
+    entt::entity createWall(const Vector3D& position, const Vector3D& halfExtents);
+    entt::entity createTrigger(const Vector3D& position, float radius);
 
-    bool destroyEntity(PlayerID id);
+    bool destroyEntity(entt::entity entity);
     void clearEntities();
-
-    // Entity queries
-    entt::entity getEntity(PlayerID id);
-    entt::entity getEntity(PlayerID id) const;
-    size_t getEntityCount() const { return m_playerToEntity.size(); }
 
     // PlayerID ↔ entt::entity mapping (for FFI compatibility)
     entt::entity getEntityByPlayerID(PlayerID id) const;
@@ -80,14 +77,13 @@ public:
     CombatSystem* getCombatSystem() { return m_combatSystem; }
     SystemManager* getSystemManager() { return &m_systemManager; }
 
-    // Convenience methods for player management (backwards compatibility)
-    entt::entity addPlayer(PlayerID playerId, const std::string& name, const Vector3D& spawnPos);
-    bool removePlayer(PlayerID playerId);
-    entt::entity getPlayer(PlayerID playerId) { return getEntity(playerId); }
-    size_t getPlayerCount() const { return m_playerCount; }
+    // Convenience methods for player management
+    entt::entity createPlayer(PlayerID id, const std::string& name, Vector3D pos);
+    bool removePlayer(PlayerID id);
+    size_t getPlayerCount() const { return m_playerToEntity.size(); }
 
     // Input handling (forwards to controller component)
-    void setPlayerInput(PlayerID playerId, const InputState& input);
+    void setPlayerInput(PlayerID id, const InputState& input);
 
     // Combat handling (forwards to combat system)
     void registerHit(PlayerID attackerId, PlayerID victimId, float damage);
@@ -95,14 +91,6 @@ public:
 private:
     // EnTT registry (core data structure)
     entt::registry m_registry;
-
-    // PlayerID ↔ entt::entity bidirectional mapping
-    std::unordered_map<PlayerID, entt::entity> m_playerToEntity;
-    std::unordered_map<entt::entity, PlayerID> m_entityToPlayer;
-
-    // Entity ID generation
-    PlayerID m_nextEntityId;
-    size_t m_playerCount;
 
     // System management
     SystemManager m_systemManager;
@@ -113,8 +101,12 @@ private:
     CollisionSystem* m_collisionSystem;
     CombatSystem* m_combatSystem;
 
+    // PlayerID ↔ entt::entity bidirectional mapping
+    std::unordered_map<PlayerID, entt::entity> m_playerToEntity;
+    std::unordered_map<entt::entity, PlayerID> m_entityToPlayer;
+
     // Internal helpers
-    void registerPlayerIDMapping(entt::entity entity, PlayerID playerId);
+    void registerPlayerIDMapping(entt::entity entity, PlayerID id);
     void unregisterPlayerIDMapping(entt::entity entity);
 };
 
@@ -122,10 +114,9 @@ private:
 // Implementation
 // =============================================================================
 
+
 inline World::World()
-    : m_nextEntityId(1000)  // Start IDs at 1000 to avoid collision with player IDs
-    , m_playerCount(0)
-    , m_characterControllerSystem(nullptr)
+    : m_characterControllerSystem(nullptr)
     , m_physicsSystem(nullptr)
     , m_collisionSystem(nullptr)
     , m_combatSystem(nullptr)
@@ -201,31 +192,17 @@ inline void World::lateUpdate(float deltaTime) {
     m_systemManager.lateUpdate(deltaTime);
 }
 
-inline entt::entity World::createEntity(PlayerID id, const std::string& name) {
-    // Check if entity already exists
-    if (m_playerToEntity.find(id) != m_playerToEntity.end()) {
-        return entt::null;
-    }
+// General entity
 
-    // Create entity in registry
+inline entt::entity World::createActor(const Vector3D& spawnPos) {
+
     entt::entity entity = m_registry.create();
-
-    // Add PlayerInfo component
-    m_registry.emplace<Components::PlayerInfo>(entity, id, name);
-
-    // Register PlayerID mapping
-    registerPlayerIDMapping(entity, id);
-
-    return entity;
-}
-
-inline entt::entity World::createCharacter(PlayerID id, const std::string& name, const Vector3D& spawnPos) {
-    entt::entity entity = createEntity(id, name);
     if (entity == entt::null) {
         return entt::null;
     }
 
-    // Initialize as character (add components)
+    // Initialize as character
+    m_registry.emplace<ActorTag>(entity);
     m_registry.emplace<Components::Transform>(entity, spawnPos);
     m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createCharacter());
     m_registry.emplace<Components::Collider>(entity, Components::Collider::createCharacter());
@@ -238,8 +215,9 @@ inline entt::entity World::createCharacter(PlayerID id, const std::string& name,
     return entity;
 }
 
-inline entt::entity World::createProjectile(PlayerID id, const Vector3D& spawnPos, const Vector3D& velocity) {
-    entt::entity entity = createEntity(id, "Projectile_" + std::to_string(id));
+inline entt::entity World::createProjectile(const Vector3D& spawnPos, const Vector3D& velocity) {
+
+    entt::entity entity = m_registry.create();;
     if (entity == entt::null) {
         return entt::null;
     }
@@ -248,6 +226,7 @@ inline entt::entity World::createProjectile(PlayerID id, const Vector3D& spawnPo
     auto physics = Components::PhysicsBody::createProjectile();
     physics.velocity = velocity;
 
+    m_registry.emplace<ProjectileTag>(entity);
     m_registry.emplace<Components::Transform>(entity, spawnPos);
     m_registry.emplace<Components::PhysicsBody>(entity, physics);
     m_registry.emplace<Components::Collider>(entity, Components::Collider::createProjectile());
@@ -255,13 +234,14 @@ inline entt::entity World::createProjectile(PlayerID id, const Vector3D& spawnPo
     return entity;
 }
 
-inline entt::entity World::createWall(PlayerID id, const Vector3D& position, const Vector3D& halfExtents) {
-    entt::entity entity = createEntity(id, "Wall_" + std::to_string(id));
+inline entt::entity World::createWall(const Vector3D& position, const Vector3D& halfExtents) {
+    entt::entity entity = m_registry.create();
     if (entity == entt::null) {
         return entt::null;
     }
 
     // Initialize as wall
+    m_registry.emplace<WallTag>(entity);
     m_registry.emplace<Components::Transform>(entity, position);
     m_registry.emplace<Components::Collider>(entity, Components::Collider::createWall(halfExtents));
     m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createStatic());
@@ -269,34 +249,28 @@ inline entt::entity World::createWall(PlayerID id, const Vector3D& position, con
     return entity;
 }
 
-inline entt::entity World::createTrigger(PlayerID id, const Vector3D& position, float radius) {
-    entt::entity entity = createEntity(id, "Trigger_" + std::to_string(id));
+inline entt::entity World::createTrigger(const Vector3D& position, float radius) {
+
+    entt::entity entity = m_registry.create();
     if (entity == entt::null) {
         return entt::null;
     }
 
     // Initialize as trigger
+    m_registry.emplace<TriggerTag>(entity);
     m_registry.emplace<Components::Transform>(entity, position);
     m_registry.emplace<Components::Collider>(entity, Components::Collider::createTrigger(radius));
 
     return entity;
 }
 
-inline bool World::destroyEntity(PlayerID id) {
-    entt::entity entity = getEntityByPlayerID(id);
-    if (entity == entt::null) {
-        return false;
-    }
-
-    // Unregister PlayerID mapping
-    unregisterPlayerIDMapping(entity);
+inline bool World::destroyEntity(entt::entity entity) {
 
     // Destroy entity (automatically removes all components)
     m_registry.destroy(entity);
 
     return true;
 }
-
 inline void World::clearEntities() {
     // Clear all mappings
     m_playerToEntity.clear();
@@ -304,46 +278,57 @@ inline void World::clearEntities() {
 
     // Clear registry (destroys all entities and components)
     m_registry.clear();
-
-    m_playerCount = 0;
 }
 
-inline entt::entity World::getEntity(PlayerID id) {
-    return getEntityByPlayerID(id);
-}
-
-inline entt::entity World::getEntity(PlayerID id) const {
-    return getEntityByPlayerID(id);
-}
+// Player related
 
 inline entt::entity World::getEntityByPlayerID(PlayerID id) const {
     auto it = m_playerToEntity.find(id);
     return (it != m_playerToEntity.end()) ? it->second : entt::null;
 }
-
 inline PlayerID World::getPlayerIDByEntity(entt::entity entity) const {
     auto it = m_entityToPlayer.find(entity);
     return (it != m_entityToPlayer.end()) ? it->second : 0;
 }
 
-inline entt::entity World::addPlayer(PlayerID playerId, const std::string& name, const Vector3D& spawnPos) {
-    entt::entity entity = createCharacter(playerId, name, spawnPos);
-    if (entity != entt::null) {
-        m_playerCount++;
+inline entt::entity World::createPlayer(PlayerID id, const std::string& name, Vector3D pos) {
+
+    // Check if entity already exists
+    if (m_playerToEntity.find(id) != m_playerToEntity.end()) {
+        return entt::null;
     }
+
+    entt::entity entity = createActor(pos);
+
+    // Add PlayerInfo component
+    m_registry.emplace<PlayerTag>(entity);
+    m_registry.emplace<Components::PlayerInfo>(entity, id, name);
+
+    // Register PlayerID mapping
+    registerPlayerIDMapping(entity, id);
+
     return entity;
 }
 
-inline bool World::removePlayer(PlayerID playerId) {
-    if (destroyEntity(playerId)) {
-        m_playerCount--;
-        return true;
+inline bool World::removePlayer(PlayerID id) {
+
+    entt::entity entity = getEntityByPlayerID(id);
+
+
+    if (entity == entt::null) {
+        return false;
     }
-    return false;
+
+    // Unregister PlayerID mapping
+    unregisterPlayerIDMapping(entity);
+
+    destroyEntity(entity);
+
+    return true;
 }
 
-inline void World::setPlayerInput(PlayerID playerId, const InputState& input) {
-    entt::entity entity = getEntityByPlayerID(playerId);
+inline void World::setPlayerInput(PlayerID id, const InputState& input) {
+    entt::entity entity = getEntityByPlayerID(id);
     if (entity == entt::null) {
         return;
     }
@@ -361,18 +346,18 @@ inline void World::registerHit(PlayerID attackerId, PlayerID victimId, float dam
     }
 }
 
-inline void World::registerPlayerIDMapping(entt::entity entity, PlayerID playerId) {
-    m_playerToEntity[playerId] = entity;
-    m_entityToPlayer[entity] = playerId;
+inline void World::registerPlayerIDMapping(entt::entity entity, PlayerID id) {
+    m_playerToEntity[id] = entity;
+    m_entityToPlayer[entity] = id;
 }
-
 inline void World::unregisterPlayerIDMapping(entt::entity entity) {
-    PlayerID playerId = getPlayerIDByEntity(entity);
-    if (playerId != 0) {
-        m_playerToEntity.erase(playerId);
+    PlayerID id = getPlayerIDByEntity(entity);
+    if (id != 0) {
+        m_playerToEntity.erase(id);
         m_entityToPlayer.erase(entity);
     }
 }
+
 
 } // namespace Core
 } // namespace ArenaGame

--- a/game_engine/include/Core/World.hpp
+++ b/game_engine/include/Core/World.hpp
@@ -85,8 +85,6 @@ public:
     // Input handling (forwards to controller component)
     void setPlayerInput(PlayerID id, const InputState& input);
 
-    // Combat handling (forwards to combat system)
-    void registerHit(PlayerID attackerId, PlayerID victimId, float damage);
 
 private:
     // EnTT registry (core data structure)
@@ -206,7 +204,7 @@ inline entt::entity World::createActor(const Vector3D& spawnPos) {
     m_registry.emplace<Components::Collider>(entity, Components::Collider::createCharacter());
     m_registry.emplace<Components::Health>(entity, Components::Health::createCharacter());
     m_registry.emplace<Components::CharacterController>(entity, Components::CharacterController::createDefault());
-    m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createMelee());
+    m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createDefault());
 
     return entity;
 }
@@ -337,12 +335,6 @@ inline void World::setPlayerInput(PlayerID id, const InputState& input) {
     auto* controller = m_registry.try_get<Components::CharacterController>(entity);
     if (controller) {
         controller->setInput(input);
-    }
-}
-
-inline void World::registerHit(PlayerID attackerId, PlayerID victimId, float damage) {
-    if (m_combatSystem) {
-        m_combatSystem->registerHit(attackerId, victimId, damage);
     }
 }
 

--- a/game_engine/include/Core/World.hpp
+++ b/game_engine/include/Core/World.hpp
@@ -78,7 +78,7 @@ public:
     SystemManager* getSystemManager() { return &m_systemManager; }
 
     // Convenience methods for player management
-    entt::entity createPlayer(PlayerID id, const std::string& name, Vector3D pos);
+    entt::entity createPlayer(PlayerID id, const std::string& name, Vector3D pos, const CharacterPreset& preset);
     bool removePlayer(PlayerID id);
     size_t getPlayerCount() const { return m_playerToEntity.size(); }
 
@@ -193,7 +193,6 @@ inline void World::lateUpdate(float deltaTime) {
 }
 
 // General entity
-
 inline entt::entity World::createActor(const Vector3D& spawnPos) {
 
     entt::entity entity = m_registry.create();
@@ -201,7 +200,6 @@ inline entt::entity World::createActor(const Vector3D& spawnPos) {
         return entt::null;
     }
 
-    // Initialize as character
     m_registry.emplace<ActorTag>(entity);
     m_registry.emplace<Components::Transform>(entity, spawnPos);
     m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createCharacter());
@@ -210,11 +208,8 @@ inline entt::entity World::createActor(const Vector3D& spawnPos) {
     m_registry.emplace<Components::CharacterController>(entity, Components::CharacterController::createDefault());
     m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createMelee());
 
-    // No need to register with systems - EnTT views handle this automatically!
-
     return entity;
 }
-
 inline entt::entity World::createProjectile(const Vector3D& spawnPos, const Vector3D& velocity) {
 
     entt::entity entity = m_registry.create();;
@@ -233,7 +228,6 @@ inline entt::entity World::createProjectile(const Vector3D& spawnPos, const Vect
 
     return entity;
 }
-
 inline entt::entity World::createWall(const Vector3D& position, const Vector3D& halfExtents) {
     entt::entity entity = m_registry.create();
     if (entity == entt::null) {
@@ -248,7 +242,6 @@ inline entt::entity World::createWall(const Vector3D& position, const Vector3D& 
 
     return entity;
 }
-
 inline entt::entity World::createTrigger(const Vector3D& position, float radius) {
 
     entt::entity entity = m_registry.create();
@@ -281,7 +274,6 @@ inline void World::clearEntities() {
 }
 
 // Player related
-
 inline entt::entity World::getEntityByPlayerID(PlayerID id) const {
     auto it = m_playerToEntity.find(id);
     return (it != m_playerToEntity.end()) ? it->second : entt::null;
@@ -291,20 +283,28 @@ inline PlayerID World::getPlayerIDByEntity(entt::entity entity) const {
     return (it != m_entityToPlayer.end()) ? it->second : 0;
 }
 
-inline entt::entity World::createPlayer(PlayerID id, const std::string& name, Vector3D pos) {
+inline entt::entity World::createPlayer(PlayerID id,
+                                        const std::string& name,
+                                        Vector3D pos,
+                                        const CharacterPreset& preset) {
 
     // Check if entity already exists
     if (m_playerToEntity.find(id) != m_playerToEntity.end()) {
         return entt::null;
     }
 
-    entt::entity entity = createActor(pos);
+    entt::entity entity = m_registry.create();
 
     // Add PlayerInfo component
     m_registry.emplace<PlayerTag>(entity);
     m_registry.emplace<Components::PlayerInfo>(entity, id, name);
+    m_registry.emplace<Components::Transform>(entity, pos);
+    m_registry.emplace<Components::Collider>(entity, Components::Collider::createCharacter());
+    m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createCharacter());
+    m_registry.emplace<Components::Health>(entity, Components::Health::createFromPreset(preset));
+    m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createFromPreset(preset));
+    m_registry.emplace<Components::CharacterController>(entity, Components::CharacterController::createFromPreset(preset));
 
-    // Register PlayerID mapping
     registerPlayerIDMapping(entity, id);
 
     return entity;

--- a/game_engine/include/GameTypes.hpp
+++ b/game_engine/include/GameTypes.hpp
@@ -203,12 +203,12 @@ struct GameConfig {
     static constexpr float CHARACTER_RADIUS = 0.5f;            // Collision radius
     static constexpr float CHARACTER_HEIGHT = 1.8f;            // Character height
     static constexpr float CHARACTER_COLLISION_RADIUS = 0.45f; // Slightly smaller for smooth collisions
-    static constexpr float CHARACTER_MOVE_SPEED = 8.0f;        // Base movement speed (m/s)
+    static constexpr float CHARACTER_MOVE_SPEED = 2.5f;        // Base movement speed (m/s)
     static constexpr float CHARACTER_MAX_SPEED = 10.0f;        // Maximum horizontal speed (m/s)
     static constexpr float CHARACTER_MAX_HEALTH = 100.0f;      // Default max health
 
     // Movement modifiers
-    static constexpr float SPRINT_MULTIPLIER = 2.5f;           // Speed when sprinting (1.5x = 50% faster)
+    static constexpr float SPRINT_MULTIPLIER = 4.0f;           // Speed when sprinting (1.5x = 50% faster)
     static constexpr float CROUCH_MULTIPLIER = 0.5f;           // Speed when crouching (0.5x = 50% slower)
     static constexpr float AIR_CONTROL_FACTOR = 0.3f;          // Movement control while airborne (0.0-1.0)
 

--- a/game_engine/include/Presets.hpp
+++ b/game_engine/include/Presets.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "CharacterPreset.hpp"
+
+namespace ArenaGame {
+namespace Presets {
+
+	// ── Player characters ──────────────────────────────────────────────
+	inline const CharacterPreset KNIGHT = {
+		.maxHealth           = 120.0f,
+		.armor               = 5.0f,
+		.movementSpeed       = 7.0f,
+		.rotationSpeed       = 1.0f,
+		.baseDamage          = 18.0f,
+		.damageMultiplier    = 1.0f,
+		.criticalChance      = 0.15f,
+		.criticalMultiplier  = 1.5f,
+		.attackChain   = {
+			// Stage 0: overhead chop — slow, rooted, moderate hit (skill description and feel)
+			{ .damageMultiplier=0.9f,
+			.range=2.0f,
+			.duration=0.5f,
+			.movementMultiplier=0.0f,
+			.chainWindow=0.8f },
+			// Stage 1: shield bash — rooted, heavy hit, ends chain
+			{ .damageMultiplier=1.6f,
+			.range=1.8f,
+			.duration=0.6f,
+			.movementMultiplier=0.0f,
+			.chainWindow=0.0f },
+		},
+		.skill1 = { MeleeAOE{
+			.range=2.0f,
+			.movementMultiplier=0.0f,
+			.dmgMultiplier=1.5f },
+			.cooldown=5.0f },
+		.skill2 = { MeleeAOE{
+			.range=2.0f,
+			.movementMultiplier=0.7f,
+			.dmgMultiplier=1.5f },
+			.cooldown=10.0f },
+	};
+/*
+	// ── AI enemies ─────────────────────────────────────────────────────
+	inline const CharacterPreset SKELETON = {
+		.baseDamage     = 8.0f,
+		.attackRange    = 1.5f,
+		.attackCooldown = 0.4f,
+		.maxHealth      = 50.0f,
+		.armor          = 0.0f,
+		.movementSpeed  = 10.0f,
+		.skill1 = { MeleeSingleTargetSkill{ 2.0f, 1.5f }, 6.0f },
+		.skill2 = { DashSkill{ 4.0f, 12.0f },             12.0f },
+	};
+ */
+};
+};

--- a/game_engine/include/Presets.hpp
+++ b/game_engine/include/Presets.hpp
@@ -9,7 +9,7 @@ namespace Presets {
 	inline const CharacterPreset KNIGHT = {
 		.maxHealth           = 120.0f,
 		.armor               = 5.0f,
-		.movementSpeed       = 7.0f,
+		.movementSpeed       = 1.5f,
 		.rotationSpeed       = 1.0f,
 		.baseDamage          = 18.0f,
 		.damageMultiplier    = 1.0f,

--- a/game_engine/include/Presets.hpp
+++ b/game_engine/include/Presets.hpp
@@ -9,6 +9,7 @@ namespace Presets {
 	inline const CharacterPreset KNIGHT = {
 		.maxHealth           = 120.0f,
 		.armor               = 5.0f,
+		.resistance          = 0.1f,
 		.movementSpeed       = 1.5f,
 		.rotationSpeed       = 1.0f,
 		.baseDamage          = 18.0f,

--- a/game_engine/include/Skills.hpp
+++ b/game_engine/include/Skills.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <variant>
+
+namespace ArenaGame {
+
+	struct MeleeAOE {
+		float range;
+		float movementMultiplier;  // 0=rooted, 1=full movement during skill
+		float dmgMultiplier;
+	};
+
+	using SkillVariant = std::variant<MeleeAOE>;
+
+	struct SkillDefinition {
+		SkillVariant params;
+		float cooldown;
+		float timer = 0.0f;
+		bool canUse() const { return timer <= 0.0f; }
+		void trigger()      { timer = cooldown; }
+	};
+
+	struct AttackStage {
+		float damageMultiplier;   // multiplied against CombatController::baseDamage
+		float range;              // reach of this swing
+		float duration;           // swing length — gates next input (chain or new attack)
+		float movementMultiplier; // caster speed during swing (0=rooted, 1=free)
+		float chainWindow;        // time after duration expires to press again and continue
+		                          // 0 on last stage means chain wraps back to stage 0
+	};
+
+} // namespace ArenaGame

--- a/game_engine/include/Skills.hpp
+++ b/game_engine/include/Skills.hpp
@@ -21,12 +21,13 @@ namespace ArenaGame {
 	};
 
 	struct AttackStage {
-		float damageMultiplier;   // multiplied against CombatController::baseDamage
-		float range;              // reach of this swing
-		float duration;           // swing length — gates next input (chain or new attack)
-		float movementMultiplier; // caster speed during swing (0=rooted, 1=free)
-		float chainWindow;        // time after duration expires to press again and continue
-		                          // 0 on last stage means chain wraps back to stage 0
+		float damageMultiplier;       // multiplied against CombatController::baseDamage
+		float range;                  // reach of this swing
+		float duration;               // swing length — gates next input (chain or new attack)
+		float movementMultiplier;     // caster speed during swing (0=rooted, 1=free)
+		float chainWindow;            // time after duration expires to press again and continue
+		                              // 0 on last stage means chain wraps back to stage 0
+		float attackAngle = 1.047f;   // half-angle in radians (≈60° → 120° frontal cone)
 	};
 
 } // namespace ArenaGame

--- a/game_engine/include/systems/CharacterControllerSystem.hpp
+++ b/game_engine/include/systems/CharacterControllerSystem.hpp
@@ -50,13 +50,11 @@ inline void CharacterControllerSystem::earlyUpdate(float deltaTime) {
         Components::Transform
     >();
 
-    for (auto entity : view) {
-        auto& controller = view.get<Components::CharacterController>(entity);
-        auto& physics = view.get<Components::PhysicsBody>(entity);
-        auto& transform = view.get<Components::Transform>(entity);
-
+    view.each([&](Components::CharacterController& controller,
+        Components::PhysicsBody& physics,
+        Components::Transform& transform) {
         processCharacterMovement(controller, physics, transform, deltaTime);
-    }
+        });
 }
 
 inline void CharacterControllerSystem::processCharacterMovement(

--- a/game_engine/include/systems/CollisionSystem.hpp
+++ b/game_engine/include/systems/CollisionSystem.hpp
@@ -76,12 +76,13 @@ inline void CollisionSystem::fixedUpdate(float fixedDeltaTime) {
     // Get view of all entities with Transform + Collider
     auto view = m_registry->view<Components::Transform, Components::Collider>();
 
+
     // Convert view to vector for indexed access (needed for O(n²) pair iteration)
     std::vector<entt::entity> entities;
     entities.reserve(view.size_hint());
-    for (auto entity : view) {
+    view.each([&](auto entity, Components::Transform& transform, Components::Collider& collider) {
         entities.push_back(entity);
-    }
+    });
 
     // Simple O(n²) collision detection
     // For larger entity counts (>50), use spatial partitioning

--- a/game_engine/include/systems/CollisionSystem.hpp
+++ b/game_engine/include/systems/CollisionSystem.hpp
@@ -12,17 +12,13 @@
 namespace ArenaGame {
 
 // =============================================================================
-// CollisionSystem - EnTT-based collision detection and resolution
+// CollisionSystem - Detects and resolves collisions between entities
 // =============================================================================
-// Drop-in replacement for CollisionSystem using EnTT views
-// - Uses view<Transform, Collider> for iteration
-// - Better performance with EnTT groups (cache-friendly)
-// - Identical collision logic to CollisionSystem.hpp
+// - Iterates all entity pairs with Transform + Collider components
+// - Filters by collision layer (shouldCollideWith) and skips dead entities
+// - Resolves overlap by pushing entities apart based on kinematic flags
 //
-// Performance improvements:
-// - Packed storage for better cache locality
-// - Can use EnTT groups for hot path optimization
-// - No manual entity tracking needed
+// Should run in fixedUpdate phase (after physics integration)
 // =============================================================================
 
 class CollisionSystem : public System {

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -7,8 +7,10 @@
 #include "Components/CombatController.hpp"
 #include "Components/CharacterController.hpp"
 #include "GameTypes.hpp"
+#include "Skills.hpp"
 #include <entt/entt.hpp>
 #include <queue>
+#include <variant>
 
 namespace ArenaGame {
 
@@ -77,6 +79,8 @@ private:
     void processAttacks();
     void processDamage();
     void updateCooldowns(float deltaTime);
+
+    inline void CombatSystem::processInputAttacks();
 };
 
 // =============================================================================
@@ -219,5 +223,55 @@ inline void CombatSystem::updateCooldowns(float deltaTime) {
         }
     }
 }
+
+inline void CombatSystem::processInputAttacks() {
+
+    auto view = m_registry->view<PlayerInfo, CharacterController, CombatController,
+                                Health, Transform, PhysicsBody>();
+
+    view.each([&] (PlayerInfo& info,
+                  CharacterController& charcon,
+                  CombatController& comcon,
+                  Health& health,
+                  Transform& trans,
+                  hysicsBody& physics) {
+
+                    SkillContext ctx {
+                        *m_registry, ,info.playerID, trans, physics, charcon, comcon, m_pendingAttacks};
+                    }
+            });
+}
+
+template<typename... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+struct SkillContext {
+    entt::registry&               registry;
+    entt::entity                  attackerEntity;
+    PlayerID                      attackerID;
+    Components::Transform&        attackerTransform;
+    Components::PhysicsBody&      attackerPhysics;   // needed for dash
+    Components::CharacterController characterCon;
+    Components::CombatController& combatCon;            // baseDamage, damageMultiplier
+    std::queue<PendingHit>&       pendingHits;       // output: damage to apply
+};
+
+inline void CombatSystem::executeSkill(SkillDefinition& skill, SkillContext& ctx) {
+    std::visit(overloaded{
+        [&](MeleeAOE& s) {hitAllInRange(ctx, s.range, s.dmgMultiplier); }
+    }, skill.params);
+}
+
+// Returns final damage for the attacker's current chain stage.
+// Applies: stage multiplier * base * global modifier * optional crit.
+inline float calculateDamage(const Components::CombatController& cc) {
+    float dmg    = cc.baseDamage * cc.currentStage().damageMultiplier * cc.damageMultiplier;
+    bool  isCrit = (static_cast<float>(std::rand()) / RAND_MAX) < cc.criticalChance;
+    return isCrit ? dmg * cc.criticalMultiplier : dmg;
+}
+
+void hitAllInRange(SkillContext& ctx, float range, float damageMultiplier);
 
 } // namespace ArenaGame

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -115,8 +115,11 @@ private:
     void processDamage();
     void updateCooldowns(float deltaTime);
 
-    // Queue hits for all living, in-range targets (excludes attacker).
+    // Queue hits for all living, in-range targets (excludes attacker). Full 360°.
     void hitAllInRange(SkillContext& ctx, float range, float dmgMultiplier);
+
+    // Queue hits for targets within a frontal arc. attackAngle is the half-angle in radians.
+    void hitInArc(SkillContext& ctx, float range, float dmgMultiplier, float attackAngle);
 
     // Dispatch skill execution via SkillVariant visitor.
     void executeSkill(SkillDefinition& skill, SkillContext& ctx);
@@ -172,7 +175,7 @@ inline void CombatSystem::processInputAttacks() {
                 charcon.canMove = false;
             }
 
-            hitAllInRange(ctx, stage.range, stage.damageMultiplier);
+            hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
             comcon.advanceChain();
 
             fprintf(stderr, "[COMBAT]         next_chain_stage=%d\n", comcon.chainStage);
@@ -215,6 +218,31 @@ inline void CombatSystem::hitAllInRange(SkillContext& ctx, float range, float dm
                 dist, dmg);
             ctx.pendingHits.push({ctx.attackerEntity, target, dmg});
         }
+    });
+}
+
+inline void CombatSystem::hitInArc(SkillContext& ctx, float range, float dmgMultiplier, float attackAngle) {
+    auto targets = m_registry->view<Components::Transform, Components::Health>();
+    Vector3D forward = ctx.attackerTransform.getForwardDirection();
+    float cosAngle = std::cos(attackAngle);
+
+    targets.each([&](entt::entity target,
+                     Components::Transform& targetTransform,
+                     Components::Health&    targetHealth) {
+        if (target == ctx.attackerEntity) return;
+        if (!targetHealth.isAlive()) return;
+
+        float dist = ctx.attackerTransform.position.distanceTo(targetTransform.position);
+        if (dist > range) return;
+
+        Vector3D toTarget = (targetTransform.position - ctx.attackerTransform.position).normalized();
+        if (forward.dot(toTarget) < cosAngle) return;
+
+        float dmg = calculateCombatDamage(ctx.combatCon, dmgMultiplier);
+        fprintf(stderr, "[COMBAT] HIT_QUEUED  attacker=%u  target=%u  dist=%.2f  raw_dmg=%.2f\n",
+            static_cast<unsigned>(ctx.attackerEntity), static_cast<unsigned>(target),
+            dist, dmg);
+        ctx.pendingHits.push({ctx.attackerEntity, target, dmg});
     });
 }
 

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -169,16 +169,12 @@ inline void CombatSystem::processInputAttacks() {
                 stage.range, stage.damageMultiplier, comcon.baseDamage);
 
             comcon.startAttack();
+            comcon.hitPending = true;   // hit lands at swing end, not swing start
             charcon.setState(CharacterState::Attacking);
 
             if (stage.movementMultiplier == 0.0f) {
                 charcon.canMove = false;
             }
-
-            hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
-            comcon.advanceChain();
-
-            fprintf(stderr, "[COMBAT]         next_chain_stage=%d\n", comcon.chainStage);
         }
 
         // ── Ability 1 ─────────────────────────────────────────────────────
@@ -286,15 +282,28 @@ inline void CombatSystem::processDamage() {
 inline void CombatSystem::updateCooldowns(float deltaTime) {
     using namespace Components;
 
-    auto view = m_registry->view<CombatController, CharacterController>();
+    auto view = m_registry->view<CombatController, CharacterController, Transform, PhysicsBody>();
 
-    view.each([&](entt::entity, CombatController& combat, CharacterController& controller) {
+    view.each([&](entt::entity entity, CombatController& combat, CharacterController& controller,
+                  Transform& trans, PhysicsBody& physics) {
         const bool wasAttacking = combat.isAttacking;
         combat.updateTimers(deltaTime);
 
-        // Restore movement when swing ends
+        // Swing just ended — restore movement and apply deferred hit
         if (wasAttacking && !combat.isAttacking) {
             controller.canMove = true;
+
+            if (combat.hitPending) {
+                auto* health = m_registry->try_get<Health>(entity);
+                if (health && health->isAlive()) {
+                    SkillContext ctx { *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
+                    const AttackStage& stage = combat.currentStage();
+                    hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
+                    combat.advanceChain();
+                    fprintf(stderr, "[COMBAT] deferred_hit applied  next_chain_stage=%d\n", combat.chainStage);
+                }
+                combat.hitPending = false;
+            }
         }
 
         // Reset CharacterState when swing ends and player is not re-triggering

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -3,6 +3,7 @@
 #include "System.hpp"
 #include "Components/PlayerInfo.hpp"
 #include "Components/Transform.hpp"
+#include "Components/PhysicsBody.hpp"
 #include "Components/Health.hpp"
 #include "Components/CombatController.hpp"
 #include "Components/CharacterController.hpp"
@@ -11,76 +12,114 @@
 #include <entt/entt.hpp>
 #include <queue>
 #include <variant>
+#include <cstdio>
+#include <cstdlib>
 
 namespace ArenaGame {
 
 // =============================================================================
-// CombatSystem - EnTT-based combat system
+// CombatSystem - Server-side ECS combat system
 // =============================================================================
-// Drop-in replacement for CombatSystem using EnTT views
-// - Uses view<Health, CombatController> for iteration
-// - Uses World for PlayerID → entity lookups
-// - Identical combat logic to CombatSystem.hpp
+// Attack chain + skills driven entirely from CharacterController input.
+// Damage is calculated server-side from CombatController preset data.
 //
-// Performance improvements:
-// - Packed storage for better cache locality
-// - Automatic filtering (view only returns entities with required components)
-// - No manual entity tracking
+// Update order per frame:
+//   1. updateCooldowns(dt)   — advance swing / chain / skill timers
+//   2. processInputAttacks() — read input, trigger attacks/skills, queue hits
+//   3. processDamage()       — apply queued hits to Health components
+//
+// Normal attack chain
+// ─────────────────────────────────────────────────────────────────────────────
+//   input.isAttacking && canPerformAttack()
+//     → startAttack()  (gates next input for stage.duration)
+//     → hitAllInRange(ctx, stage.range, stage.damageMultiplier)
+//     → advanceChain() (stage++ or wrap to 0 on last/no-window stage)
+//
+//   If player does not re-press within attackChain[prev].chainWindow,
+//   updateTimers() resets chainStage → 0.
+//
+// Skills
+// ─────────────────────────────────────────────────────────────────────────────
+//   input.isUsingAbility1/2 && canUseAbility1/2()
+//     → executeSkill(skill, ctx)  (dispatches over SkillVariant)
+//     → useAbility1/2()           (starts cooldown timer)
+// =============================================================================
+
+// Visitor helper for std::visit over SkillVariant
+template<typename... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template<typename... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+// Returns final damage: baseDamage × stageMultiplier × globalMultiplier ± crit.
+// stageMultiplier comes from AttackStage::damageMultiplier or SkillDefinition::dmgMultiplier.
+inline float calculateCombatDamage(const Components::CombatController& cc, float stageMultiplier) {
+    float dmg = cc.baseDamage * stageMultiplier * cc.damageMultiplier;
+    bool isCrit = (static_cast<float>(std::rand()) / RAND_MAX) < cc.criticalChance;
+    return isCrit ? dmg * cc.criticalMultiplier : dmg;
+}
+
+// =============================================================================
+// SkillContext - bundle passed to every skill / hit handler
+// =============================================================================
+// Carries all attacker state needed for skill execution and hit detection.
+// PhysicsBody is included for future dash-style skills.
+
+class CombatSystem;  // forward
+
+struct PendingHit {
+    entt::entity attacker;
+    entt::entity victim;
+    float        damage;
+};
+
+struct SkillContext {
+    entt::registry&                  registry;
+    entt::entity                     attackerEntity;
+    Components::Transform&           attackerTransform;
+    Components::PhysicsBody&         attackerPhysics;    // for dash / knockback skills
+    Components::CharacterController& characterCon;
+    Components::CombatController&    combatCon;
+    std::queue<PendingHit>&          pendingHits;        // output: damage to apply
+};
+
+// =============================================================================
+// CombatSystem
 // =============================================================================
 
 class CombatSystem : public System {
 public:
     CombatSystem() = default;
 
-    // System interface
     void update(float deltaTime) override;
     const char* getName() const override { return "CombatSystem"; }
 
-    // Combat actions
-    void registerHit(PlayerID attackerID, PlayerID victimID, float damage);
-    void requestAttack(PlayerID playerID);
-
-    // Combat configuration (same as CombatSystem)
     struct Config {
-        float meleeRange = 2.0f;        // Range for melee attacks
-        float meleeDamage = 10.0f;      // Base melee damage
-        float attackCooldown = 0.5f;    // Time between attacks
-        bool friendlyFire = false;      // Can players damage each other?
+        bool friendlyFire = false;
     };
 
     const Config& getConfig() const { return m_config; }
     void setConfig(const Config& config) { m_config = config; }
 
-    // Clear pending actions (for shutdown)
     void clear() {
         while (!m_pendingHits.empty()) m_pendingHits.pop();
-        while (!m_pendingAttacks.empty()) m_pendingAttacks.pop();
     }
 
 private:
     Config m_config;
-
-    // Pending hits to process
-    struct PendingHit {
-        PlayerID attackerID;
-        PlayerID victimID;
-        float damage;
-    };
     std::queue<PendingHit> m_pendingHits;
 
-    // Pending attacks to process
-    struct PendingAttack {
-        PlayerID playerID;
-    };
-    std::queue<PendingAttack> m_pendingAttacks;
-
-    // Helper methods
-    entt::entity findEntity(PlayerID playerID);
-    void processAttacks();
+    void processInputAttacks();
     void processDamage();
     void updateCooldowns(float deltaTime);
 
-    inline void CombatSystem::processInputAttacks();
+    // Queue hits for all living, in-range targets (excludes attacker).
+    void hitAllInRange(SkillContext& ctx, float range, float dmgMultiplier);
+
+    // Dispatch skill execution via SkillVariant visitor.
+    void executeSkill(SkillDefinition& skill, SkillContext& ctx);
 };
 
 // =============================================================================
@@ -88,77 +127,103 @@ private:
 // =============================================================================
 
 inline void CombatSystem::update(float deltaTime) {
-    // Process all pending attacks
-    processAttacks();
-
-    // Process all pending damage
-    processDamage();
-
-    // Update cooldowns
     updateCooldowns(deltaTime);
+    processInputAttacks();
+    processDamage();
 }
 
-inline void CombatSystem::registerHit(PlayerID attackerID, PlayerID victimID, float damage) {
-    m_pendingHits.push({attackerID, victimID, damage});
-}
+inline void CombatSystem::processInputAttacks() {
+    using namespace Components;
 
-inline void CombatSystem::requestAttack(PlayerID playerID) {
-    m_pendingAttacks.push({playerID});
-}
+    auto view = m_registry->view<
+        CharacterController,
+        CombatController,
+        Health,
+        Transform,
+        PhysicsBody
+    >();
 
-inline entt::entity CombatSystem::findEntity(PlayerID playerID) {
-    if (!m_registry) {
-        return entt::null;
-    }
+    view.each([&](entt::entity entity,
+                  CharacterController& charcon,
+                  CombatController&    comcon,
+                  Health&              health,
+                  Transform&           trans,
+                  PhysicsBody&         physics) {
 
-    // Search through all entities with PlayerInfo component
-    auto view = m_registry->view<Components::PlayerInfo>();
-    for (auto entity : view) {
-        auto& playerInfo = view.get<Components::PlayerInfo>(entity);
-        if (playerInfo.playerID == playerID) {
-            return entity;
-        }
-    }
+        if (!health.isAlive()) return;
 
-    return entt::null;
-}
+        SkillContext ctx {
+            *m_registry, entity,
+            trans, physics, charcon, comcon, m_pendingHits
+        };
 
-inline void CombatSystem::processAttacks() {
-    while (!m_pendingAttacks.empty()) {
-        PendingAttack attack = m_pendingAttacks.front();
-        m_pendingAttacks.pop();
+        // ── Normal attack ─────────────────────────────────────────────────
+        if (charcon.input.isAttacking && comcon.canPerformAttack()) {
+            const AttackStage& stage = comcon.currentStage();
 
-        entt::entity attacker = findEntity(attack.playerID);
-        if (attacker == entt::null) {
-            continue;
-        }
+            fprintf(stderr, "[COMBAT] ATTACK  entity=%u  chain_stage=%d  range=%.1f  dmg_mul=%.2f  base_dmg=%.1f\n",
+                static_cast<unsigned>(entity), comcon.chainStage,
+                stage.range, stage.damageMultiplier, comcon.baseDamage);
 
-        // Check if entity has combat component and is alive
-        auto* combat = m_registry->try_get<Components::CombatController>(attacker);
-        auto* health = m_registry->try_get<Components::Health>(attacker);
+            comcon.startAttack();
+            charcon.setState(CharacterState::Attacking);
 
-        if (!combat || (health && !health->isAlive())) {
-            continue;
-        }
-
-        // Try to initiate attack
-        if (combat->canPerformAttack()) {
-            combat->startAttack();
-
-            // Update character state if has controller
-            if (auto* controller = m_registry->try_get<Components::CharacterController>(attacker)) {
-                controller->setState(CharacterState::Attacking);
+            if (stage.movementMultiplier == 0.0f) {
+                charcon.canMove = false;
             }
 
-            // In a full implementation, you'd:
-            // 1. Check for targets in range
-            // 2. Apply damage to those targets
-            // 3. Trigger attack animations/effects
+            hitAllInRange(ctx, stage.range, stage.damageMultiplier);
+            comcon.advanceChain();
 
-            // For now, this is handled by registerHit() being called
-            // from the game logic when client confirms a hit
+            fprintf(stderr, "[COMBAT]         next_chain_stage=%d\n", comcon.chainStage);
         }
-    }
+
+        // ── Ability 1 ─────────────────────────────────────────────────────
+        if (charcon.input.isUsingAbility1 && comcon.canUseAbility1()) {
+            fprintf(stderr, "[COMBAT] ABILITY1 entity=%u  cd=%.2f\n",
+                static_cast<unsigned>(entity), comcon.ability1.timer);
+            executeSkill(comcon.ability1, ctx);
+            comcon.useAbility1();
+            charcon.setState(CharacterState::Casting);
+        }
+
+        // ── Ability 2 ─────────────────────────────────────────────────────
+        if (charcon.input.isUsingAbility2 && comcon.canUseAbility2()) {
+            fprintf(stderr, "[COMBAT] ABILITY2 entity=%u  cd=%.2f\n",
+                static_cast<unsigned>(entity), comcon.ability2.timer);
+            executeSkill(comcon.ability2, ctx);
+            comcon.useAbility2();
+            charcon.setState(CharacterState::Casting);
+        }
+    });
+}
+
+inline void CombatSystem::hitAllInRange(SkillContext& ctx, float range, float dmgMultiplier) {
+    auto targets = m_registry->view<Components::Transform, Components::Health>();
+
+    targets.each([&](entt::entity target,
+                     Components::Transform& targetTransform,
+                     Components::Health&    targetHealth) {
+        if (target == ctx.attackerEntity) return;
+        if (!targetHealth.isAlive()) return;
+
+        float dist = ctx.attackerTransform.position.distanceTo(targetTransform.position);
+        if (dist <= range) {
+            float dmg = calculateCombatDamage(ctx.combatCon, dmgMultiplier);
+            fprintf(stderr, "[COMBAT] HIT_QUEUED  attacker=%u  target=%u  dist=%.2f  raw_dmg=%.2f\n",
+                static_cast<unsigned>(ctx.attackerEntity), static_cast<unsigned>(target),
+                dist, dmg);
+            ctx.pendingHits.push({ctx.attackerEntity, target, dmg});
+        }
+    });
+}
+
+inline void CombatSystem::executeSkill(SkillDefinition& skill, SkillContext& ctx) {
+    std::visit(overloaded{
+        [&](MeleeAOE& s) {
+            hitAllInRange(ctx, s.range, s.dmgMultiplier);
+        }
+    }, skill.params);
 }
 
 inline void CombatSystem::processDamage() {
@@ -166,112 +231,58 @@ inline void CombatSystem::processDamage() {
         PendingHit hit = m_pendingHits.front();
         m_pendingHits.pop();
 
-        entt::entity victim = findEntity(hit.victimID);
-        if (victim == entt::null) {
-            continue;
+        auto* health = m_registry->try_get<Components::Health>(hit.victim);
+        if (!health || !health->isAlive()) continue;
+
+        PlayerID attackerID = 0;
+        if (auto* info = m_registry->try_get<Components::PlayerInfo>(hit.attacker)) {
+            attackerID = info->playerID;
         }
 
-        // Get health component
-        auto* health = m_registry->try_get<Components::Health>(victim);
-        if (!health || !health->isAlive()) {
-            continue;
-        }
+        float hpBefore = health->current;
+        health->takeDamage(hit.damage, attackerID);
+        float hpAfter = health->current;
 
-        // Check friendly fire
-        if (!m_config.friendlyFire && hit.attackerID == hit.victimID) {
-            continue;
-        }
+        fprintf(stderr, "[COMBAT] DAMAGE  attacker_pid=%u  victim=%u  raw=%.2f  dealt=%.2f  hp: %.1f -> %.1f / %.1f  %s\n",
+            attackerID, static_cast<unsigned>(hit.victim),
+            hit.damage, hpBefore - hpAfter,
+            hpBefore, hpAfter, health->maximum,
+            health->isAlive() ? "" : "DEAD");
 
-        // Apply damage
-        health->takeDamage(hit.damage, hit.attackerID);
-
-        // Check if victim died
         if (!health->isAlive()) {
-            // Update character state if has controller
-            if (auto* controller = m_registry->try_get<Components::CharacterController>(victim)) {
+            fprintf(stderr, "[COMBAT] KILL  attacker_pid=%u  victim=%u\n",
+                attackerID, static_cast<unsigned>(hit.victim));
+            if (auto* controller = m_registry->try_get<Components::CharacterController>(hit.victim)) {
                 controller->setState(CharacterState::Dead);
+                controller->canMove = false;
             }
-
-            // Could trigger death events, respawn logic, etc.
-            // For now, character is just marked as dead
         }
     }
 }
 
 inline void CombatSystem::updateCooldowns(float deltaTime) {
-    // Get all entities with combat controller
-    auto view = m_registry->view<Components::CombatController>();
+    using namespace Components;
 
-    for (auto entity : view) {
-        auto& combat = view.get<Components::CombatController>(entity);
+    auto view = m_registry->view<CombatController, CharacterController>();
 
-        // Update timers
+    view.each([&](entt::entity, CombatController& combat, CharacterController& controller) {
+        const bool wasAttacking = combat.isAttacking;
         combat.updateTimers(deltaTime);
 
-        // Check if attack finished and update state
-        auto* controller = m_registry->try_get<Components::CharacterController>(entity);
-        if (controller && !combat.isAttacking) {
-            // Only reset state if player isn't still holding attack button
-            if (controller->state == CharacterState::Attacking && !controller->input.isAttacking) {
-                // Return to idle or moving based on input
-                if (controller->hasMovementInput()) {
-                    controller->setState(CharacterState::Moving);
-                } else {
-                    controller->setState(CharacterState::Idle);
-                }
+        // Restore movement when swing ends
+        if (wasAttacking && !combat.isAttacking) {
+            controller.canMove = true;
+        }
+
+        // Reset CharacterState when swing ends and player is not re-triggering
+        if (!combat.isAttacking && controller.state == CharacterState::Attacking) {
+            if (!controller.input.isAttacking) {
+                controller.setState(controller.hasMovementInput()
+                    ? CharacterState::Moving
+                    : CharacterState::Idle);
             }
         }
-    }
+    });
 }
-
-inline void CombatSystem::processInputAttacks() {
-
-    auto view = m_registry->view<PlayerInfo, CharacterController, CombatController,
-                                Health, Transform, PhysicsBody>();
-
-    view.each([&] (PlayerInfo& info,
-                  CharacterController& charcon,
-                  CombatController& comcon,
-                  Health& health,
-                  Transform& trans,
-                  hysicsBody& physics) {
-
-                    SkillContext ctx {
-                        *m_registry, ,info.playerID, trans, physics, charcon, comcon, m_pendingAttacks};
-                    }
-            });
-}
-
-template<typename... Ts>
-struct overloaded : Ts... {
-    using Ts::operator()...;
-};
-
-struct SkillContext {
-    entt::registry&               registry;
-    entt::entity                  attackerEntity;
-    PlayerID                      attackerID;
-    Components::Transform&        attackerTransform;
-    Components::PhysicsBody&      attackerPhysics;   // needed for dash
-    Components::CharacterController characterCon;
-    Components::CombatController& combatCon;            // baseDamage, damageMultiplier
-    std::queue<PendingHit>&       pendingHits;       // output: damage to apply
-};
-
-inline void CombatSystem::executeSkill(SkillDefinition& skill, SkillContext& ctx) {
-    std::visit(overloaded{
-        [&](MeleeAOE& s) {hitAllInRange(ctx, s.range, s.dmgMultiplier); }
-    }, skill.params);
-}
-
-// Returns final damage for the attacker's current chain stage.
-// Applies: stage multiplier * base * global modifier * optional crit.
-inline float calculateDamage(const Components::CombatController& cc) {
-    float dmg    = cc.baseDamage * cc.currentStage().damageMultiplier * cc.damageMultiplier;
-    bool  isCrit = (static_cast<float>(std::rand()) / RAND_MAX) < cc.criticalChance;
-    return isCrit ? dmg * cc.criticalMultiplier : dmg;
-}
-
-void hitAllInRange(SkillContext& ctx, float range, float damageMultiplier);
 
 } // namespace ArenaGame

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "System.hpp"
-#include "Components/PlayerInfo.hpp"
 #include "Components/Transform.hpp"
+#include <cstdio>
 #include "Components/PhysicsBody.hpp"
 #include "Components/Health.hpp"
 #include "Components/CombatController.hpp"
@@ -234,24 +234,19 @@ inline void CombatSystem::processDamage() {
         auto* health = m_registry->try_get<Components::Health>(hit.victim);
         if (!health || !health->isAlive()) continue;
 
-        PlayerID attackerID = 0;
-        if (auto* info = m_registry->try_get<Components::PlayerInfo>(hit.attacker)) {
-            attackerID = info->playerID;
-        }
-
         float hpBefore = health->current;
-        health->takeDamage(hit.damage, attackerID);
-        float hpAfter = health->current;
+        health->takeDamage(hit.damage, hit.attacker);
+        float hpAfter  = health->current;
 
-        fprintf(stderr, "[COMBAT] DAMAGE  attacker_pid=%u  victim=%u  raw=%.2f  dealt=%.2f  hp: %.1f -> %.1f / %.1f  %s\n",
-            attackerID, static_cast<unsigned>(hit.victim),
-            hit.damage, hpBefore - hpAfter,
+        fprintf(stderr, "[COMBAT] attacker=%u  victim=%u  raw=%.2f  dealt=%.2f  hp: %.1f -> %.1f / %.1f%s\n",
+            static_cast<unsigned>(hit.attacker),
+            static_cast<unsigned>(hit.victim),
+            hit.damage,
+            hpBefore - hpAfter,
             hpBefore, hpAfter, health->maximum,
-            health->isAlive() ? "" : "DEAD");
+            health->isAlive() ? "" : "  DEAD");
 
         if (!health->isAlive()) {
-            fprintf(stderr, "[COMBAT] KILL  attacker_pid=%u  victim=%u\n",
-                attackerID, static_cast<unsigned>(hit.victim));
             if (auto* controller = m_registry->try_get<Components::CharacterController>(hit.victim)) {
                 controller->setState(CharacterState::Dead);
                 controller->canMove = false;

--- a/game_engine/include/systems/CombatSystem.hpp
+++ b/game_engine/include/systems/CombatSystem.hpp
@@ -286,6 +286,18 @@ inline void CombatSystem::updateCooldowns(float deltaTime) {
 
     view.each([&](entt::entity entity, CombatController& combat, CharacterController& controller,
                   Transform& trans, PhysicsBody& physics) {
+        // Movement cancels the swing — mirrors client animation cancellation
+        if (combat.isAttacking && controller.hasMovementInput()) {
+            combat.isAttacking = false;
+            combat.swingTimer  = 0.0f;
+            combat.hitPending  = false;
+            controller.canMove = true;
+            controller.setState(CharacterState::Moving);
+            fprintf(stderr, "[COMBAT] swing cancelled by movement  entity=%u\n",
+                static_cast<unsigned>(entity));
+            return;
+        }
+
         const bool wasAttacking = combat.isAttacking;
         combat.updateTimers(deltaTime);
 

--- a/game_engine/include/systems/PhysicsSystem.hpp
+++ b/game_engine/include/systems/PhysicsSystem.hpp
@@ -61,12 +61,9 @@ private:
 
 inline void PhysicsSystem::fixedUpdate(float fixedDeltaTime) {
     // EnTT view: iterate only entities with Transform AND PhysicsBody
-    // This is cached and very fast (packed storage)
     auto view = m_registry->view<Components::Transform, Components::PhysicsBody>();
 
-    for (auto entity : view) {
-        auto& transform = view.get<Components::Transform>(entity);
-        auto& physics = view.get<Components::PhysicsBody>(entity);
+    view.each([&](Components::Transform& transform,Components::PhysicsBody& physics){
 
         // Apply physics forces
         applyGravity(physics, fixedDeltaTime);
@@ -77,7 +74,8 @@ inline void PhysicsSystem::fixedUpdate(float fixedDeltaTime) {
         // Enforce constraints
         enforceArenaBounds(transform);
         checkGroundCollision(transform, physics);
-    }
+
+    });
 }
 
 inline void PhysicsSystem::applyGravity(Components::PhysicsBody& physics, float deltaTime) {

--- a/game_engine/include/systems/PhysicsSystem.hpp
+++ b/game_engine/include/systems/PhysicsSystem.hpp
@@ -9,17 +9,13 @@
 namespace ArenaGame {
 
 // =============================================================================
-// PhysicsSystem - EnTT-based physics simulation
+// PhysicsSystem - Simulates gravity, friction, and positional integration
 // =============================================================================
-// Drop-in replacement for PhysicsSystem using EnTT views
-// - Uses view<Transform, PhysicsBody> for cache-friendly iteration
-// - No manual entity tracking (EnTT handles this)
-// - Identical physics logic to PhysicsSystem.hpp
+// - Applies gravity and friction to all entities with PhysicsBody
+// - Integrates velocity into position (Euler integration)
+// - Enforces arena bounds and ground collision
 //
-// Performance improvements:
-// - 10-20x faster iteration (packed component storage)
-// - No need to check hasPhysics() (view filters automatically)
-// - Better cache locality
+// Should run in fixedUpdate phase (before collision)
 // =============================================================================
 
 class PhysicsSystem : public System {

--- a/game_engine/include/systems/System.hpp
+++ b/game_engine/include/systems/System.hpp
@@ -50,12 +50,12 @@ public:
     virtual const char* getName() const = 0;
 
     // Update phase flags (override to indicate which phases this system needs)
-    virtual bool needsEarlyUpdate() const { return false; }
-    virtual bool needsFixedUpdate() const { return false; }
-    virtual bool needsUpdate() const { return true; }  // Most systems need this
-    virtual bool needsLateUpdate() const { return false; }
+    virtual bool needsEarlyUpdate() const { return false; } // Input
+    virtual bool needsFixedUpdate() const { return false; } // Physics, Collision
+    virtual bool needsUpdate() const { return true; }      // Game logic, Combat, AI
+    virtual bool needsLateUpdate() const { return false; } // Post-processing, interpolation
 
-    // Set registry (called during world initialization)
+    // Called during world initialization
     void setRegistry(entt::registry* registry) {
         m_registry = registry;
     }

--- a/game_engine/include/systems/SystemManager.hpp
+++ b/game_engine/include/systems/SystemManager.hpp
@@ -11,8 +11,7 @@ namespace ArenaGame {
 // =============================================================================
 // SystemManager - Manages EnTT-based game systems
 // =============================================================================
-// Drop-in replacement for SystemManager that works with System instances
-// - Identical interface to SystemManager
+// SystemManager works with System instances
 // - Manages System lifecycle
 // - Handles multi-phase updates
 //

--- a/game_engine/src/game_bindings.cpp
+++ b/game_engine/src/game_bindings.cpp
@@ -59,7 +59,7 @@ size_t game_get_player_count(Game* game) {
 // =============================================================================
 // Entity Management
 // =============================================================================
-
+/*
 // Create a projectile entity
 bool game_create_projectile(
     Game* game,
@@ -107,12 +107,12 @@ bool game_entity_is_alive(Game* game, uint32_t entity_id) {
     auto* health = registry.try_get<Components::Health>(entity);
     return health && health->isAlive();
 }
-
+ */
 // =============================================================================
 // Component Access
 // =============================================================================
 
-// Get entity health
+/* // Get entity health
 bool game_get_entity_health(Game* game, uint32_t entity_id, float* out_current, float* out_max) {
     entt::entity entity = game->getEntity(entity_id);
     if (entity == entt::null) return false;
@@ -193,7 +193,7 @@ bool game_set_entity_velocity(Game* game, uint32_t entity_id, float x, float y, 
 
     physics->velocity = Vector3D(x, y, z);
     return true;
-}
+} */
 
 // =============================================================================
 // Input Handling
@@ -243,7 +243,7 @@ struct CGameStateSnapshot {
     uint64_t frame_number;
     double timestamp;
     size_t character_count;
-    CCharacterSnapshot characters[32]; // Max 32 players
+    CCharacterSnapshot characters[GameConfig::MAX_PLAYERS]; // Max 32 players
 };
 
 void game_get_snapshot(Game* game, CGameStateSnapshot* out_snapshot) {
@@ -251,7 +251,7 @@ void game_get_snapshot(Game* game, CGameStateSnapshot* out_snapshot) {
 
     out_snapshot->frame_number = snapshot.frameNumber;
     out_snapshot->timestamp = snapshot.timestamp;
-    out_snapshot->character_count = std::min(snapshot.characters.size(), size_t(32));
+    out_snapshot->character_count = std::min(snapshot.characters.size(), size_t(GameConfig::MAX_PLAYERS));
 
     for (size_t i = 0; i < out_snapshot->character_count; ++i) {
         const auto& src = snapshot.characters[i];

--- a/game_engine/src/game_bindings.cpp
+++ b/game_engine/src/game_bindings.cpp
@@ -283,12 +283,4 @@ double game_get_game_time(Game* game) {
     return game->getGameTime();
 }
 
-// =============================================================================
-// Combat
-// =============================================================================
-
-void game_register_hit(Game* game, uint32_t attacker_id, uint32_t victim_id, float damage) {
-    game->registerHit(attacker_id, victim_id, damage);
-}
-
 } // extern "C"


### PR DESCRIPTION
feat(combat): server-authoritative combat system                                                            
                                                                                                              
  - ECS refactor: entity API decoupled from PlayerID using tag components (PlayerTag, ActorTag, etc.);        
  entt::entity used throughout for attacker tracking                                                          
  - Attack chain: ordered AttackStage sequence per character — each stage has its own damage multiplier,      
  range, swing duration, movement multiplier, frontal cone angle, and chain window                            
  - Skills system: SkillDefinition with SkillVariant (currently MeleeAOE) and per-skill cooldown timers       
  - Character presets: CharacterPreset bundles health, armor, resistance, movement, and full combat config;   
  KNIGHT preset included                                                                                      
  - Damage formula: CombatSystem computes raw damage → flat armor reduction → percentage resistance; applied  
  in Health::takeDamage                                                                                       
  - Combat constraints: attacks restricted to frontal arc; movement locked during swings; movement cancelable 
  during attack wind-up                                                                                       
  - HUD: local player health bar (bottom center) + floating world-space health bars above enemies, updated    
  each frame via BabylonJS GUI                                                                                
  - Fixes: leaked window event listeners on client unmount; dev script process termination                    

[game-server] combat system - Closes #75
[game-server] hit registration system (change to be server-authoritative) - Closes #76