### PR TITLE
Feat/fe/gdpr compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,31 @@ SQLite was chosen because:
 | `data` | BLOB | CBOR-encoded `Notification` enum value |
 | `created_at` | DATETIME | |
 
+### `account_deletion_requests`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `user_id` | INTEGER PK FK | References `users(id)` ON DELETE CASCADE |
+| `token` | BLOB | 32-byte random token, base64url-encoded in API responses |
+| `confirm_token` | BLOB nullable | 32-byte email confirmation token; NULL after confirmed |
+| `expires_at` | DATETIME | 30 minutes from initiation |
+
+### `data_export_requests`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `user_id` | INTEGER PK FK | References `users(id)` ON DELETE CASCADE |
+| `token` | BLOB | 32-byte random token, base64url-encoded in API responses |
+| `confirm_token` | BLOB nullable | 32-byte email confirmation token; NULL after confirmed |
+| `expires_at` | DATETIME | 30 minutes from initiation |
+
 ### Relationships summary
 
 - One user has many sessions (cascade delete).
 - One user has many recovery codes (cascade delete).
 - One user has at most one large avatar and one small avatar (cascade delete).
 - One user has many notifications (cascade delete).
+- One user has at most one pending deletion request and one pending export request (cascade delete).
 - Sessions reference users; avatars and notifications are user-scoped.
 
 ---
@@ -291,6 +310,7 @@ SQLite was chosen because:
 | TOTP 2FA | kwurster (backend), lmeubrin (frontend) | RFC 6238 TOTP. Secret encrypted at rest. Single-use recovery codes stored as hashes. Enable/confirm/disable flow. |
 | Rate limiting | kwurster | IP-based limits on register/login. User + IP limits on authenticated endpoints. |
 | HTTPS / TLS | kwurster | Salvo + Rustls; all cookies `Secure`, `HttpOnly`, `SameSite=Lax`. |
+| GDPR compliance | kwurster (backend), lmeubrin (frontend) | Account deletion (pseudo-anonymization) and personal data export via three-phase token flow. Password + MFA verification at each step. Email confirmation for verified users. Frontend "Privacy & Data" modal with nickname confirmation for deletion. |
 
 ### Session Management
 
@@ -533,6 +553,7 @@ In a competitive multiplayer fighting game, audio is not cosmetic: it is core ga
 - Notification system: `notifications` table, CBOR-encoded `Notification` enum, `ServerHello`
 - Frontend WebTransport: codec `CompressedCborCodec.ts` (CBOR + zstd) and Stream manager
 - Backend CI/CD pipeline
+- GDPR backend: account deletion (pseudo-anonymization), data export, three-phase token flow, email confirmation endpoints, 56 integration tests
 - Full backend test infrastructure: mock server, `ApiClient`, `User` typestate, test conventions
 
 ### asplavnic
@@ -557,6 +578,7 @@ In a competitive multiplayer fighting game, audio is not cosmetic: it is core ga
 - Landing page: `LandingPage.tsx` and animated `LandingScene.tsx`
 - Design system: 11 UI components (`Button`, `Card`, `Modal`, `Input`, `Alert`, `Badge`, `Dropdown`, `InfoBlock`, `ErrorBanner`, `LoadingSpinner`, `Layout`), stone/gold/dungeon theme, full Tailwind custom config
 - Error system: `storeError` / `retrieveStoredError` pattern, `ErrorBanner` component
+- GDPR frontend: Privacy & Data modal with account deletion and data export flows, nickname confirmation for deletion, WCAG-compliant step-based UI
 - Frontend CI/CD pipeline
 - WCAG 2.1 AA accessibility compliance (Module 11): Dropdown keyboard navigation, Modal focus trap and focus restoration, skip link, `prefers-reduced-motion` support, ARIA landmarks, descriptive labels, game canvas text alternative
 

--- a/frontend/src/api/error.ts
+++ b/frontend/src/api/error.ts
@@ -83,6 +83,12 @@ function getMessageFromBrief(brief: string): string {
 		// Email confirmation errors
 		AlreadyConfirmed: 'Your email is already confirmed.',
 
+		// GDPR errors
+		InvalidToken: 'This request is invalid or has already been used. Please start over.',
+		TokenExpired: 'This request has expired (30-minute limit). Please start a new one.',
+		EmailConfirmationPending: 'Please confirm via the email we sent before proceeding.',
+		AlreadyDeleted: 'This account has already been deleted.',
+
 		// Success messages
 		DidLogout: 'You have been logged out successfully.',
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -140,7 +140,6 @@ export interface ExportNotification {
 	created_at: string;
 }
 
-
 // ==================== API ERROR TYPES ====================
 
 export interface ApiError {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -82,6 +82,65 @@ export interface FriendRequestResponse {
 	updated_at: string;
 }
 
+// ==================== GDPR TYPES ====================
+
+export interface GdprInitiateResponse {
+	token: string;
+	email_confirmation_required: boolean;
+	expires_at: string;
+}
+
+export interface DataExport {
+	exported_at: string;
+	user: ExportUser;
+	sessions: ExportSession[];
+	friend_requests: ExportFriendRequest[];
+	notifications: ExportNotification[];
+	avatar_large_base64: string | null;
+	avatar_small_base64: string | null;
+}
+
+export interface ExportUser {
+	id: number;
+	email: string;
+	nickname: string;
+	totp_enabled: boolean;
+	totp_confirmed_at: string | null;
+	created_at: string;
+	description: string;
+	tos_accepted_at: string | null;
+	email_confirmed_at: string | null;
+	pending_email_change: string | null;
+}
+
+export interface ExportSession {
+	id: number;
+	user_id: number;
+	device_id: string;
+	device_name: string | null;
+	ip_address: string | null;
+	created_at: string;
+	refreshed_at: string;
+	last_used_at: string;
+	last_authenticated_at: string;
+}
+
+export interface ExportFriendRequest {
+	id: number;
+	sender_id: number;
+	receiver_id: number;
+	status: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface ExportNotification {
+	id: number;
+	payload: unknown;
+	created_at: string;
+}
+
+
 // ==================== API ERROR TYPES ====================
 
 export interface ApiError {

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -2,6 +2,8 @@ import apiClient from './client';
 import type {
 	AuthResponse,
 	ChangePasswordPayload,
+	DataExport,
+	GdprInitiateResponse,
 	PasswordMfaPayload,
 	Session,
 	SessionManagementPayload,
@@ -130,4 +132,32 @@ export async function logoutSessions(
 		mfa_code,
 	};
 	await apiClient.post('/user/logout-sessions', payload);
+}
+
+// ==================== GDPR: ACCOUNT DELETION ====================
+
+export async function deleteMyAccount(
+	password: string,
+	mfa_code?: string,
+	token?: string,
+): Promise<GdprInitiateResponse | void> {
+	const params = token ? { token } : undefined;
+	const response = await apiClient.delete('/user/delete-my-account', {
+		data: { password, mfa_code },
+		params,
+	});
+	if (response.status === 204) return;
+	return response.data as GdprInitiateResponse;
+}
+
+// ==================== GDPR: DATA EXPORT ====================
+
+export async function exportMyData(
+	password: string,
+	mfa_code?: string,
+	token?: string,
+): Promise<GdprInitiateResponse | DataExport> {
+	const params = token ? { token } : undefined;
+	const response = await apiClient.post('/user/export-my-data', { password, mfa_code }, { params });
+	return response.data;
 }

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -158,6 +158,10 @@ export async function exportMyData(
 	token?: string,
 ): Promise<GdprInitiateResponse | DataExport> {
 	const params = token ? { token } : undefined;
-	const response = await apiClient.post('/user/export-my-data', { password, mfa_code }, { params });
+	const response = await apiClient.post(
+		'/user/export-my-data',
+		{ password, mfa_code },
+		{ params },
+	);
 	return response.data;
 }

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -336,9 +336,7 @@ export default function Home({ onLogout, onSessions }: HomeProps) {
 			{showCreateLobby && <CreateLobbyModal onClose={() => setShowCreateLobby(false)} />}
 			{showJoinByCode && <JoinByCodeModal onClose={() => setShowJoinByCode(false)} />}
 
-			{showDataPrivacy && (
-				<DataPrivacyModal onClose={() => setShowDataPrivacy(false)} />
-			)}
+			{showDataPrivacy && <DataPrivacyModal onClose={() => setShowDataPrivacy(false)} />}
 
 
 			{showReauthModal && (

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -338,7 +338,6 @@ export default function Home({ onLogout, onSessions }: HomeProps) {
 
 			{showDataPrivacy && <DataPrivacyModal onClose={() => setShowDataPrivacy(false)} />}
 
-
 			{showReauthModal && (
 				<ReauthModal
 					onSuccess={handleReauthSuccess}

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,5 +1,6 @@
 import {
 	ChevronDown,
+	Fingerprint,
 	LogOut,
 	Mail,
 	Monitor,
@@ -18,6 +19,7 @@ import { useAvatarUrls } from '../hooks/useAvatarUrls';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import AudioSettingsModal from './modals/AudioSettingsModal';
 import CreateLobbyModal from './modals/CreateLobbyModal';
+import DataPrivacyModal from './modals/DataPrivacyModal';
 import EditUserModal from './modals/EditUserModal';
 import EmailConfirmationModal from './modals/EmailConfirmationModal';
 import JoinByCodeModal from './modals/JoinByCodeModal';
@@ -54,6 +56,7 @@ export default function Home({ onLogout, onSessions }: HomeProps) {
 	const [showLobbyList, setShowLobbyList] = useState(false);
 	const [showCreateLobby, setShowCreateLobby] = useState(false);
 	const [showJoinByCode, setShowJoinByCode] = useState(false);
+	const [showDataPrivacy, setShowDataPrivacy] = useState(false);
 	const pendingActionRef = useRef<(() => void) | null>(null);
 	const { avatarSmallUrl, avatarLargeUrl, setAvatarUrls } = useAvatarUrls();
 	const [description, setDescription] = useState(user?.description ?? '');
@@ -175,6 +178,13 @@ export default function Home({ onLogout, onSessions }: HomeProps) {
 						}
 					>
 						Email Confirmation
+					</DropdownItem>
+
+					<DropdownItem
+						icon={<Fingerprint className="w-4 h-4" />}
+						onClick={() => setShowDataPrivacy(true)}
+					>
+						Privacy & Data
 					</DropdownItem>
 
 					<DropdownSeparator />
@@ -325,6 +335,11 @@ export default function Home({ onLogout, onSessions }: HomeProps) {
 			{showLobbyList && <LobbyListModal onClose={() => setShowLobbyList(false)} />}
 			{showCreateLobby && <CreateLobbyModal onClose={() => setShowCreateLobby(false)} />}
 			{showJoinByCode && <JoinByCodeModal onClose={() => setShowJoinByCode(false)} />}
+
+			{showDataPrivacy && (
+				<DataPrivacyModal onClose={() => setShowDataPrivacy(false)} />
+			)}
+
 
 			{showReauthModal && (
 				<ReauthModal

--- a/frontend/src/components/modals/DataPrivacyModal.tsx
+++ b/frontend/src/components/modals/DataPrivacyModal.tsx
@@ -1,0 +1,510 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { ShieldCheck, Download, Trash2 } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { deleteMyAccount, exportMyData } from '../../api/user';
+import { getErrorMessage, getErrorBrief } from '../../api/error';
+import { validateMfaCode } from '../../utils/validation';
+import { Modal, Button, Card, Alert, Input } from '../ui';
+import type { GdprInitiateResponse, DataExport } from '../../api/types';
+
+type GdprFlowStep =
+	| 'idle'
+	| 'credentials'
+	| 'initiating'
+	| 'awaiting_email'
+	| 'confirm_credentials'
+	| 'executing'
+	| 'done';
+
+interface GdprFlowState {
+	step: GdprFlowStep;
+	token: string | null;
+	emailConfirmationRequired: boolean;
+	expiresAt: string | null;
+	error: string | null;
+	exportData: DataExport | null;
+}
+
+const INITIAL_FLOW_STATE: GdprFlowState = {
+	step: 'idle',
+	token: null,
+	emailConfirmationRequired: false,
+	expiresAt: null,
+	error: null,
+	exportData: null,
+};
+
+interface DataPrivacyModalProps {
+	onClose: () => void;
+}
+
+export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
+	const { user, clearAuth } = useAuth();
+
+	const [exportFlow, setExportFlow] = useState<GdprFlowState>(INITIAL_FLOW_STATE);
+	const [deleteFlow, setDeleteFlow] = useState<GdprFlowState>(INITIAL_FLOW_STATE);
+
+	// Credential refs — kept out of state to avoid leaking via React DevTools
+	const exportPasswordRef = useRef<HTMLInputElement>(null);
+	const exportMfaRef = useRef<HTMLInputElement>(null);
+	const deletePasswordRef = useRef<HTMLInputElement>(null);
+	const deleteMfaRef = useRef<HTMLInputElement>(null);
+
+	// Inline validation error state
+	const [exportPasswordError, setExportPasswordError] = useState('');
+	const [exportMfaError, setExportMfaError] = useState('');
+	const [deletePasswordError, setDeletePasswordError] = useState('');
+	const [deleteMfaError, setDeleteMfaError] = useState('');
+
+	// Nickname confirmation for delete execute step
+	const [deleteNickname, setDeleteNickname] = useState('');
+	const [deleteNicknameError, setDeleteNicknameError] = useState('');
+
+	// Clear credential refs on tab visibility change (security pattern from SessionManagement)
+	useEffect(() => {
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				if (exportPasswordRef.current) exportPasswordRef.current.value = '';
+				if (exportMfaRef.current) exportMfaRef.current.value = '';
+				if (deletePasswordRef.current) deletePasswordRef.current.value = '';
+				if (deleteMfaRef.current) deleteMfaRef.current.value = '';
+			}
+		};
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+	}, []);
+
+	// Focus management — focus password input on step transitions
+	useEffect(() => {
+		if (exportFlow.step === 'credentials' || exportFlow.step === 'confirm_credentials') {
+			exportPasswordRef.current?.focus();
+		}
+	}, [exportFlow.step]);
+
+	useEffect(() => {
+		if (deleteFlow.step === 'credentials' || deleteFlow.step === 'confirm_credentials') {
+			deletePasswordRef.current?.focus();
+		}
+	}, [deleteFlow.step]);
+
+	const validateCredentials = useCallback(
+		(
+			action: 'export' | 'delete',
+		): { password: string; mfaCode: string | undefined } | null => {
+			const passwordRef = action === 'export' ? exportPasswordRef : deletePasswordRef;
+			const mfaRef = action === 'export' ? exportMfaRef : deleteMfaRef;
+			const setPasswordError = action === 'export' ? setExportPasswordError : setDeletePasswordError;
+			const setMfaError = action === 'export' ? setExportMfaError : setDeleteMfaError;
+
+			const password = passwordRef.current?.value ?? '';
+			const mfaCode = mfaRef.current?.value || undefined;
+
+			let valid = true;
+
+			if (!password) {
+				setPasswordError('Password is required.');
+				valid = false;
+			} else {
+				setPasswordError('');
+			}
+
+			if (user?.totp_enabled && mfaCode) {
+				const mfaErr = validateMfaCode(mfaCode);
+				if (mfaErr) {
+					setMfaError(mfaErr);
+					valid = false;
+				} else {
+					setMfaError('');
+				}
+			} else if (user?.totp_enabled && !mfaCode) {
+				setMfaError('Authentication code is required.');
+				valid = false;
+			} else {
+				setMfaError('');
+			}
+
+			return valid ? { password, mfaCode } : null;
+		},
+		[user?.totp_enabled],
+	);
+
+	// ── Initiate handler ──────────────────────────────────────
+	const handleInitiate = useCallback(
+		async (action: 'export' | 'delete') => {
+			const creds = validateCredentials(action);
+			if (!creds) return;
+
+			const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
+			setFlow(prev => ({ ...prev, step: 'initiating', error: null }));
+
+			try {
+				const apiFn = action === 'export' ? exportMyData : deleteMyAccount;
+				const response = await apiFn(creds.password, creds.mfaCode);
+				const initResponse = response as GdprInitiateResponse;
+
+				setFlow(prev => ({
+					...prev,
+					token: initResponse.token,
+					emailConfirmationRequired: initResponse.email_confirmation_required,
+					expiresAt: initResponse.expires_at,
+					step: initResponse.email_confirmation_required
+						? 'awaiting_email'
+						: 'confirm_credentials',
+				}));
+			} catch (err) {
+				setFlow(prev => ({
+					...prev,
+					step: 'credentials',
+					error: getErrorMessage(err, `Failed to initiate ${action}`),
+				}));
+			}
+		},
+		[validateCredentials],
+	);
+
+	// ── Execute handler ───────────────────────────────────────
+	const handleExecute = useCallback(
+		async (action: 'export' | 'delete') => {
+			const creds = validateCredentials(action);
+			if (!creds) return;
+
+			const flow = action === 'export' ? exportFlow : deleteFlow;
+			const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
+
+			// Nickname confirmation for delete
+			if (action === 'delete') {
+				if (deleteNickname !== user?.nickname) {
+					setDeleteNicknameError('Nickname does not match.');
+					return;
+				}
+				setDeleteNicknameError('');
+			}
+
+			setFlow(prev => ({ ...prev, step: 'executing', error: null }));
+
+			try {
+				const apiFn = action === 'export' ? exportMyData : deleteMyAccount;
+				const response = await apiFn(creds.password, creds.mfaCode, flow.token!);
+
+				if (action === 'export') {
+					const data = response as DataExport;
+					triggerDownload(data);
+					setExportFlow(prev => ({
+						...prev,
+						step: 'done',
+						exportData: data,
+					}));
+				} else {
+					setDeleteFlow(prev => ({ ...prev, step: 'done' }));
+					setTimeout(() => clearAuth(), 2000);
+				}
+			} catch (err) {
+				const brief = getErrorBrief(err);
+				if (brief === 'EmailConfirmationPending') {
+					setFlow(prev => ({
+						...prev,
+						step: 'awaiting_email',
+						error: 'Please confirm via the email link before proceeding.',
+					}));
+				} else if (brief === 'TokenExpired' || brief === 'InvalidToken') {
+					setFlow({
+						...INITIAL_FLOW_STATE,
+						error:
+							brief === 'TokenExpired'
+								? 'Your request has expired. Please start over.'
+								: 'This request is invalid. Please start over.',
+					});
+				} else {
+					setFlow(prev => ({
+						...prev,
+						step: 'confirm_credentials',
+						error: getErrorMessage(err, `Failed to complete ${action}`),
+					}));
+				}
+			}
+		},
+		[validateCredentials, exportFlow, deleteFlow, deleteNickname, user?.nickname, clearAuth],
+	);
+
+	// ── Download handler ──────────────────────────────────────
+	const triggerDownload = useCallback((data: DataExport) => {
+		const blob = new Blob([JSON.stringify(data, null, 2)], {
+			type: 'application/json',
+		});
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `my-data-export-${new Date().toISOString().slice(0, 10)}.json`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}, []);
+
+	const handleDownloadExport = useCallback(() => {
+		if (!exportFlow.exportData) return;
+		triggerDownload(exportFlow.exportData);
+	}, [exportFlow.exportData, triggerDownload]);
+
+	// ── Credential form (reused by both sections) ─────────────
+	const renderCredentialInputs = (
+		action: 'export' | 'delete',
+		phase: 'initiate' | 'execute',
+	) => {
+		const passwordRef = action === 'export' ? exportPasswordRef : deletePasswordRef;
+		const mfaRef = action === 'export' ? exportMfaRef : deleteMfaRef;
+		const passwordError = action === 'export' ? exportPasswordError : deletePasswordError;
+		const mfaError = action === 'export' ? exportMfaError : deleteMfaError;
+		const setPasswordErr = action === 'export' ? setExportPasswordError : setDeletePasswordError;
+		const setMfaErr = action === 'export' ? setExportMfaError : setDeleteMfaError;
+		const flow = action === 'export' ? exportFlow : deleteFlow;
+		const isLoading = flow.step === 'initiating' || flow.step === 'executing';
+
+		const handleSubmit = () => {
+			if (phase === 'initiate') handleInitiate(action);
+			else handleExecute(action);
+		};
+
+		const handleKeyDown = (e: React.KeyboardEvent) => {
+			if (e.key === 'Enter') handleSubmit();
+		};
+
+		return (
+			<div className="space-y-3">
+				{phase === 'execute' && (
+					<p className="text-sm text-stone-300">
+						Re-enter your credentials to complete the {action === 'export' ? 'data export' : 'account deletion'}.
+					</p>
+				)}
+
+				{action === 'delete' && phase === 'execute' && (
+					<Input
+						label={`Type your username "${user?.nickname}" to confirm`}
+						id={`${action}-nickname-confirm`}
+						value={deleteNickname}
+						onChange={e => {
+							setDeleteNickname(e.target.value);
+							setDeleteNicknameError('');
+						}}
+						error={deleteNicknameError}
+						onKeyDown={handleKeyDown}
+						autoComplete="off"
+						placeholder={user?.nickname ?? ''}
+					/>
+				)}
+
+				<Input
+					ref={passwordRef}
+					label="Password"
+					type="password"
+					id={`${action}-${phase}-password`}
+					autoComplete="current-password"
+					error={passwordError}
+					onChange={() => setPasswordErr('')}
+					onKeyDown={handleKeyDown}
+				/>
+
+				{user?.totp_enabled && (
+					<Input
+						ref={mfaRef}
+						label="Authentication Code"
+						variant="code"
+						id={`${action}-${phase}-mfa`}
+						autoComplete="one-time-code"
+						placeholder="000000 or recovery code"
+						error={mfaError}
+						onChange={() => setMfaErr('')}
+						onKeyDown={handleKeyDown}
+					/>
+				)}
+
+				<div className="flex gap-3 pt-1">
+					<Button
+						onClick={handleSubmit}
+						loading={isLoading}
+						loadingText={phase === 'initiate' ? 'Verifying...' : action === 'export' ? 'Exporting...' : 'Deleting...'}
+						variant={action === 'delete' && phase === 'execute' ? 'danger' : 'primary'}
+						disabled={action === 'delete' && phase === 'execute' && deleteNickname !== user?.nickname}
+						className="flex-1"
+					>
+						{phase === 'initiate'
+							? 'Continue'
+							: action === 'export'
+								? 'Download My Data'
+								: 'Permanently Delete My Account'}
+					</Button>
+					<Button
+						onClick={() => {
+							if (action === 'export') setExportFlow(INITIAL_FLOW_STATE);
+							else {
+								setDeleteFlow(INITIAL_FLOW_STATE);
+								setDeleteNickname('');
+								setDeleteNicknameError('');
+							}
+						}}
+						variant="secondary"
+					>
+						Cancel
+					</Button>
+				</div>
+			</div>
+		);
+	};
+
+	// ── Awaiting email step (reused) ──────────────────────────
+	const renderAwaitingEmail = (action: 'export' | 'delete') => {
+		const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
+
+		return (
+			<div className="space-y-3">
+				<Alert variant="info">
+					<p className="font-semibold mb-1">Check your email</p>
+					<p className="text-xs opacity-90">
+						We sent a confirmation link to your email address. Click the link,
+						then return here and press Continue. The link expires in 30 minutes.
+					</p>
+				</Alert>
+				<Button onClick={() => setFlow(prev => ({ ...prev, step: 'confirm_credentials' }))}>
+					I've Confirmed — Continue
+				</Button>
+			</div>
+		);
+	};
+
+	return (
+		<Modal onClose={onClose} title="Privacy & Data" icon={<ShieldCheck className="w-6 h-6" />} maxWidth="lg">
+			{/* ── Export My Data ──────────────────────────────── */}
+			<section aria-labelledby="export-heading">
+				<Card accent="info">
+					<div className="flex items-center gap-2 mb-3">
+						<Download className="w-5 h-5 text-info" aria-hidden="true" />
+						<h3 id="export-heading" className="text-lg font-bold text-stone-50">
+							Export My Data
+						</h3>
+					</div>
+
+					<p className="text-sm text-stone-300 mb-4">
+						Download a copy of all personal data we store about you (GDPR Article 20).
+						This includes your profile, sessions, friend requests, notifications, and avatars.
+					</p>
+
+					{/* Screen reader announcements */}
+					<div aria-live="polite" aria-atomic="true" className="sr-only">
+						{exportFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
+						{exportFlow.step === 'done' && 'Data export complete. File has been downloaded.'}
+					</div>
+
+					{exportFlow.error && (
+						<Alert
+							variant="error"
+							dismissable
+							onDismiss={() => setExportFlow(prev => ({ ...prev, error: null }))}
+							className="mb-3"
+						>
+							{exportFlow.error}
+						</Alert>
+					)}
+
+					{exportFlow.step === 'idle' && (
+						<Button
+							onClick={() => setExportFlow(prev => ({ ...prev, step: 'credentials' }))}
+							icon={<Download className="w-4 h-4" />}
+						>
+							Export My Data
+						</Button>
+					)}
+
+					{(exportFlow.step === 'credentials' || exportFlow.step === 'initiating') &&
+						renderCredentialInputs('export', 'initiate')}
+
+					{exportFlow.step === 'awaiting_email' && renderAwaitingEmail('export')}
+
+					{(exportFlow.step === 'confirm_credentials' || exportFlow.step === 'executing') &&
+						renderCredentialInputs('export', 'execute')}
+
+					{exportFlow.step === 'done' && exportFlow.exportData && (
+						<div className="space-y-3">
+							<Alert variant="success">
+								Your data export has been downloaded.
+							</Alert>
+							<Button
+								onClick={handleDownloadExport}
+								icon={<Download className="w-4 h-4" />}
+								variant="secondary"
+								fullWidth
+							>
+								Download Again
+							</Button>
+						</div>
+					)}
+				</Card>
+			</section>
+
+			{/* ── Separator ──────────────────────────────────── */}
+			<hr className="my-6 border-stone-700" />
+
+			{/* ── Delete My Account ──────────────────────────── */}
+			<section aria-labelledby="delete-heading">
+				<Card accent="danger">
+					<div className="flex items-center gap-2 mb-3">
+						<Trash2 className="w-5 h-5 text-danger" aria-hidden="true" />
+						<h3 id="delete-heading" className="text-lg font-bold text-stone-50">
+							Delete My Account
+						</h3>
+					</div>
+
+					<Alert variant="warning" className="mb-4">
+						<p className="font-semibold mb-1">This action is permanent</p>
+						<p className="text-xs opacity-90">
+							Your account will be anonymized and all personal data erased.
+							This includes your profile, sessions, avatars, friend requests,
+							and notifications. This cannot be undone.
+						</p>
+					</Alert>
+
+					{/* Screen reader announcements */}
+					<div aria-live="assertive" aria-atomic="true" className="sr-only">
+						{deleteFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
+						{deleteFlow.step === 'done' && 'Your account has been deleted. Redirecting.'}
+					</div>
+
+					{deleteFlow.error && (
+						<Alert
+							variant="error"
+							dismissable
+							onDismiss={() => setDeleteFlow(prev => ({ ...prev, error: null }))}
+							className="mb-3"
+						>
+							{deleteFlow.error}
+						</Alert>
+					)}
+
+					{deleteFlow.step === 'idle' && (
+						<Button
+							onClick={() => setDeleteFlow(prev => ({ ...prev, step: 'credentials' }))}
+							variant="danger"
+							icon={<Trash2 className="w-4 h-4" />}
+						>
+							Delete My Account
+						</Button>
+					)}
+
+					{(deleteFlow.step === 'credentials' || deleteFlow.step === 'initiating') &&
+						renderCredentialInputs('delete', 'initiate')}
+
+					{deleteFlow.step === 'awaiting_email' && renderAwaitingEmail('delete')}
+
+					{(deleteFlow.step === 'confirm_credentials' || deleteFlow.step === 'executing') &&
+						renderCredentialInputs('delete', 'execute')}
+
+					{deleteFlow.step === 'done' && (
+						<Alert variant="success">
+							<p className="font-semibold mb-1">Account deleted</p>
+							<p className="text-xs opacity-90">
+								Your account has been permanently deleted. You will be redirected shortly.
+							</p>
+						</Alert>
+					)}
+				</Card>
+			</section>
+		</Modal>
+	);
+}

--- a/frontend/src/components/modals/DataPrivacyModal.tsx
+++ b/frontend/src/components/modals/DataPrivacyModal.tsx
@@ -22,7 +22,6 @@ interface GdprFlowState {
 	emailConfirmationRequired: boolean;
 	expiresAt: string | null;
 	error: string | null;
-	exportData: DataExport | null;
 }
 
 const INITIAL_FLOW_STATE: GdprFlowState = {
@@ -31,7 +30,6 @@ const INITIAL_FLOW_STATE: GdprFlowState = {
 	emailConfirmationRequired: false,
 	expiresAt: null,
 	error: null,
-	exportData: null,
 };
 
 interface DataPrivacyModalProps {
@@ -44,23 +42,28 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 	const [exportFlow, setExportFlow] = useState<GdprFlowState>(INITIAL_FLOW_STATE);
 	const [deleteFlow, setDeleteFlow] = useState<GdprFlowState>(INITIAL_FLOW_STATE);
 
-	// Credential refs — kept out of state to avoid leaking via React DevTools
 	const exportPasswordRef = useRef<HTMLInputElement>(null);
 	const exportMfaRef = useRef<HTMLInputElement>(null);
 	const deletePasswordRef = useRef<HTMLInputElement>(null);
 	const deleteMfaRef = useRef<HTMLInputElement>(null);
+	const exportDataRef = useRef<DataExport | null>(null);
+	const deleteTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-	// Inline validation error state
 	const [exportPasswordError, setExportPasswordError] = useState('');
 	const [exportMfaError, setExportMfaError] = useState('');
 	const [deletePasswordError, setDeletePasswordError] = useState('');
 	const [deleteMfaError, setDeleteMfaError] = useState('');
 
-	// Nickname confirmation for delete execute step
 	const [deleteNickname, setDeleteNickname] = useState('');
 	const [deleteNicknameError, setDeleteNicknameError] = useState('');
 
-	// Clear credential refs on tab visibility change (security pattern from SessionManagement)
+	useEffect(() => {
+		return () => {
+			if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+		};
+	}, []);
+
+	// Wipe credential inputs when the tab loses focus to avoid leaking secrets
 	useEffect(() => {
 		const handleVisibilityChange = () => {
 			if (document.hidden) {
@@ -128,7 +131,6 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 		[user?.totp_enabled],
 	);
 
-	// ── Initiate handler ──────────────────────────────────────
 	const handleInitiate = useCallback(
 		async (action: 'export' | 'delete') => {
 			const creds = validateCredentials(action);
@@ -162,16 +164,25 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 		[validateCredentials],
 	);
 
-	// ── Execute handler ───────────────────────────────────────
+	const triggerDownload = useCallback((data: DataExport) => {
+		const blob = new Blob([JSON.stringify(data, null, 2)], {
+			type: 'application/json',
+		});
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `my-data-export-${new Date().toISOString().slice(0, 10)}.json`;
+		a.click();
+		setTimeout(() => URL.revokeObjectURL(url), 100);
+	}, []);
+
 	const handleExecute = useCallback(
 		async (action: 'export' | 'delete') => {
 			const creds = validateCredentials(action);
 			if (!creds) return;
 
-			const flow = action === 'export' ? exportFlow : deleteFlow;
 			const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
 
-			// Nickname confirmation for delete
 			if (action === 'delete') {
 				if (deleteNickname !== user?.nickname) {
 					setDeleteNicknameError('Nickname does not match.');
@@ -180,23 +191,26 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 				setDeleteNicknameError('');
 			}
 
-			setFlow(prev => ({ ...prev, step: 'executing', error: null }));
+			// Read token from current state to avoid stale closure
+			const token = await new Promise<string | null>(resolve => {
+				setFlow(prev => {
+					resolve(prev.token);
+					return { ...prev, step: 'executing', error: null };
+				});
+			});
 
 			try {
 				const apiFn = action === 'export' ? exportMyData : deleteMyAccount;
-				const response = await apiFn(creds.password, creds.mfaCode, flow.token!);
+				const response = await apiFn(creds.password, creds.mfaCode, token!);
 
 				if (action === 'export') {
 					const data = response as DataExport;
 					triggerDownload(data);
-					setExportFlow(prev => ({
-						...prev,
-						step: 'done',
-						exportData: data,
-					}));
+					exportDataRef.current = data;
+					setExportFlow(prev => ({ ...prev, step: 'done' }));
 				} else {
 					setDeleteFlow(prev => ({ ...prev, step: 'done' }));
-					setTimeout(() => clearAuth(), 2000);
+					deleteTimerRef.current = setTimeout(() => clearAuth(), 2000);
 				}
 			} catch (err) {
 				const brief = getErrorBrief(err);
@@ -223,28 +237,14 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 				}
 			}
 		},
-		[validateCredentials, exportFlow, deleteFlow, deleteNickname, user?.nickname, clearAuth],
+		[validateCredentials, deleteNickname, user?.nickname, clearAuth, triggerDownload],
 	);
 
-	// ── Download handler ──────────────────────────────────────
-	const triggerDownload = useCallback((data: DataExport) => {
-		const blob = new Blob([JSON.stringify(data, null, 2)], {
-			type: 'application/json',
-		});
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `my-data-export-${new Date().toISOString().slice(0, 10)}.json`;
-		a.click();
-		URL.revokeObjectURL(url);
-	}, []);
-
 	const handleDownloadExport = useCallback(() => {
-		if (!exportFlow.exportData) return;
-		triggerDownload(exportFlow.exportData);
-	}, [exportFlow.exportData, triggerDownload]);
+		if (!exportDataRef.current) return;
+		triggerDownload(exportDataRef.current);
+	}, [triggerDownload]);
 
-	// ── Credential form (reused by both sections) ─────────────
 	const renderCredentialInputs = (
 		action: 'export' | 'delete',
 		phase: 'initiate' | 'execute',
@@ -349,7 +349,6 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 		);
 	};
 
-	// ── Awaiting email step (reused) ──────────────────────────
 	const renderAwaitingEmail = (action: 'export' | 'delete') => {
 		const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
 
@@ -371,7 +370,6 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 	return (
 		<Modal onClose={onClose} title="Privacy & Data" icon={<ShieldCheck className="w-6 h-6" />} maxWidth="lg">
-			{/* ── Export My Data ──────────────────────────────── */}
 			<section aria-labelledby="export-heading">
 				<Card accent="info">
 					<div className="flex items-center gap-2 mb-3">
@@ -386,7 +384,6 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 						This includes your profile, sessions, friend requests, notifications, and avatars.
 					</p>
 
-					{/* Screen reader announcements */}
 					<div aria-live="polite" aria-atomic="true" className="sr-only">
 						{exportFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
 						{exportFlow.step === 'done' && 'Data export complete. File has been downloaded.'}
@@ -420,7 +417,7 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 					{(exportFlow.step === 'confirm_credentials' || exportFlow.step === 'executing') &&
 						renderCredentialInputs('export', 'execute')}
 
-					{exportFlow.step === 'done' && exportFlow.exportData && (
+					{exportFlow.step === 'done' && (
 						<div className="space-y-3">
 							<Alert variant="success">
 								Your data export has been downloaded.
@@ -438,10 +435,8 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 				</Card>
 			</section>
 
-			{/* ── Separator ──────────────────────────────────── */}
 			<hr className="my-6 border-stone-700" />
 
-			{/* ── Delete My Account ──────────────────────────── */}
 			<section aria-labelledby="delete-heading">
 				<Card accent="danger">
 					<div className="flex items-center gap-2 mb-3">
@@ -460,7 +455,6 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 						</p>
 					</Alert>
 
-					{/* Screen reader announcements */}
 					<div aria-live="assertive" aria-atomic="true" className="sr-only">
 						{deleteFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
 						{deleteFlow.step === 'done' && 'Your account has been deleted. Redirecting.'}

--- a/frontend/src/components/modals/DataPrivacyModal.tsx
+++ b/frontend/src/components/modals/DataPrivacyModal.tsx
@@ -91,12 +91,11 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 	}, [deleteFlow.step]);
 
 	const validateCredentials = useCallback(
-		(
-			action: 'export' | 'delete',
-		): { password: string; mfaCode: string | undefined } | null => {
+		(action: 'export' | 'delete'): { password: string; mfaCode: string | undefined } | null => {
 			const passwordRef = action === 'export' ? exportPasswordRef : deletePasswordRef;
 			const mfaRef = action === 'export' ? exportMfaRef : deleteMfaRef;
-			const setPasswordError = action === 'export' ? setExportPasswordError : setDeletePasswordError;
+			const setPasswordError =
+				action === 'export' ? setExportPasswordError : setDeletePasswordError;
 			const setMfaError = action === 'export' ? setExportMfaError : setDeleteMfaError;
 
 			const password = passwordRef.current?.value ?? '';
@@ -137,14 +136,14 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 			if (!creds) return;
 
 			const setFlow = action === 'export' ? setExportFlow : setDeleteFlow;
-			setFlow(prev => ({ ...prev, step: 'initiating', error: null }));
+			setFlow((prev) => ({ ...prev, step: 'initiating', error: null }));
 
 			try {
 				const apiFn = action === 'export' ? exportMyData : deleteMyAccount;
 				const response = await apiFn(creds.password, creds.mfaCode);
 				const initResponse = response as GdprInitiateResponse;
 
-				setFlow(prev => ({
+				setFlow((prev) => ({
 					...prev,
 					token: initResponse.token,
 					emailConfirmationRequired: initResponse.email_confirmation_required,
@@ -154,7 +153,7 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 						: 'confirm_credentials',
 				}));
 			} catch (err) {
-				setFlow(prev => ({
+				setFlow((prev) => ({
 					...prev,
 					step: 'credentials',
 					error: getErrorMessage(err, `Failed to initiate ${action}`),
@@ -192,8 +191,8 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 			}
 
 			// Read token from current state to avoid stale closure
-			const token = await new Promise<string | null>(resolve => {
-				setFlow(prev => {
+			const token = await new Promise<string | null>((resolve) => {
+				setFlow((prev) => {
 					resolve(prev.token);
 					return { ...prev, step: 'executing', error: null };
 				});
@@ -207,15 +206,15 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 					const data = response as DataExport;
 					triggerDownload(data);
 					exportDataRef.current = data;
-					setExportFlow(prev => ({ ...prev, step: 'done' }));
+					setExportFlow((prev) => ({ ...prev, step: 'done' }));
 				} else {
-					setDeleteFlow(prev => ({ ...prev, step: 'done' }));
+					setDeleteFlow((prev) => ({ ...prev, step: 'done' }));
 					deleteTimerRef.current = setTimeout(() => clearAuth(), 2000);
 				}
 			} catch (err) {
 				const brief = getErrorBrief(err);
 				if (brief === 'EmailConfirmationPending') {
-					setFlow(prev => ({
+					setFlow((prev) => ({
 						...prev,
 						step: 'awaiting_email',
 						error: 'Please confirm via the email link before proceeding.',
@@ -229,7 +228,7 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 								: 'This request is invalid. Please start over.',
 					});
 				} else {
-					setFlow(prev => ({
+					setFlow((prev) => ({
 						...prev,
 						step: 'confirm_credentials',
 						error: getErrorMessage(err, `Failed to complete ${action}`),
@@ -245,15 +244,13 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 		triggerDownload(exportDataRef.current);
 	}, [triggerDownload]);
 
-	const renderCredentialInputs = (
-		action: 'export' | 'delete',
-		phase: 'initiate' | 'execute',
-	) => {
+	const renderCredentialInputs = (action: 'export' | 'delete', phase: 'initiate' | 'execute') => {
 		const passwordRef = action === 'export' ? exportPasswordRef : deletePasswordRef;
 		const mfaRef = action === 'export' ? exportMfaRef : deleteMfaRef;
 		const passwordError = action === 'export' ? exportPasswordError : deletePasswordError;
 		const mfaError = action === 'export' ? exportMfaError : deleteMfaError;
-		const setPasswordErr = action === 'export' ? setExportPasswordError : setDeletePasswordError;
+		const setPasswordErr =
+			action === 'export' ? setExportPasswordError : setDeletePasswordError;
 		const setMfaErr = action === 'export' ? setExportMfaError : setDeleteMfaError;
 		const flow = action === 'export' ? exportFlow : deleteFlow;
 		const isLoading = flow.step === 'initiating' || flow.step === 'executing';
@@ -271,7 +268,8 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 			<div className="space-y-3">
 				{phase === 'execute' && (
 					<p className="text-sm text-stone-300">
-						Re-enter your credentials to complete the {action === 'export' ? 'data export' : 'account deletion'}.
+						Re-enter your credentials to complete the{' '}
+						{action === 'export' ? 'data export' : 'account deletion'}.
 					</p>
 				)}
 
@@ -280,7 +278,7 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 						label={`Type your username "${user?.nickname}" to confirm`}
 						id={`${action}-nickname-confirm`}
 						value={deleteNickname}
-						onChange={e => {
+						onChange={(e) => {
 							setDeleteNickname(e.target.value);
 							setDeleteNicknameError('');
 						}}
@@ -320,9 +318,19 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 					<Button
 						onClick={handleSubmit}
 						loading={isLoading}
-						loadingText={phase === 'initiate' ? 'Verifying...' : action === 'export' ? 'Exporting...' : 'Deleting...'}
+						loadingText={
+							phase === 'initiate'
+								? 'Verifying...'
+								: action === 'export'
+									? 'Exporting...'
+									: 'Deleting...'
+						}
 						variant={action === 'delete' && phase === 'execute' ? 'danger' : 'primary'}
-						disabled={action === 'delete' && phase === 'execute' && deleteNickname !== user?.nickname}
+						disabled={
+							action === 'delete' &&
+							phase === 'execute' &&
+							deleteNickname !== user?.nickname
+						}
 						className="flex-1"
 					>
 						{phase === 'initiate'
@@ -357,11 +365,13 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 				<Alert variant="info">
 					<p className="font-semibold mb-1">Check your email</p>
 					<p className="text-xs opacity-90">
-						We sent a confirmation link to your email address. Click the link,
-						then return here and press Continue. The link expires in 30 minutes.
+						We sent a confirmation link to your email address. Click the link, then
+						return here and press Continue. The link expires in 30 minutes.
 					</p>
 				</Alert>
-				<Button onClick={() => setFlow(prev => ({ ...prev, step: 'confirm_credentials' }))}>
+				<Button
+					onClick={() => setFlow((prev) => ({ ...prev, step: 'confirm_credentials' }))}
+				>
 					I've Confirmed — Continue
 				</Button>
 			</div>
@@ -369,7 +379,12 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 	};
 
 	return (
-		<Modal onClose={onClose} title="Privacy & Data" icon={<ShieldCheck className="w-6 h-6" />} maxWidth="lg">
+		<Modal
+			onClose={onClose}
+			title="Privacy & Data"
+			icon={<ShieldCheck className="w-6 h-6" />}
+			maxWidth="lg"
+		>
 			<section aria-labelledby="export-heading">
 				<Card accent="info">
 					<div className="flex items-center gap-2 mb-3">
@@ -381,19 +396,22 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 					<p className="text-sm text-stone-300 mb-4">
 						Download a copy of all personal data we store about you (GDPR Article 20).
-						This includes your profile, sessions, friend requests, notifications, and avatars.
+						This includes your profile, sessions, friend requests, notifications, and
+						avatars.
 					</p>
 
 					<div aria-live="polite" aria-atomic="true" className="sr-only">
-						{exportFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
-						{exportFlow.step === 'done' && 'Data export complete. File has been downloaded.'}
+						{exportFlow.step === 'awaiting_email' &&
+							'Check your email for a confirmation link.'}
+						{exportFlow.step === 'done' &&
+							'Data export complete. File has been downloaded.'}
 					</div>
 
 					{exportFlow.error && (
 						<Alert
 							variant="error"
 							dismissable
-							onDismiss={() => setExportFlow(prev => ({ ...prev, error: null }))}
+							onDismiss={() => setExportFlow((prev) => ({ ...prev, error: null }))}
 							className="mb-3"
 						>
 							{exportFlow.error}
@@ -402,7 +420,9 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 					{exportFlow.step === 'idle' && (
 						<Button
-							onClick={() => setExportFlow(prev => ({ ...prev, step: 'credentials' }))}
+							onClick={() =>
+								setExportFlow((prev) => ({ ...prev, step: 'credentials' }))
+							}
 							icon={<Download className="w-4 h-4" />}
 						>
 							Export My Data
@@ -414,14 +434,13 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 					{exportFlow.step === 'awaiting_email' && renderAwaitingEmail('export')}
 
-					{(exportFlow.step === 'confirm_credentials' || exportFlow.step === 'executing') &&
+					{(exportFlow.step === 'confirm_credentials' ||
+						exportFlow.step === 'executing') &&
 						renderCredentialInputs('export', 'execute')}
 
 					{exportFlow.step === 'done' && (
 						<div className="space-y-3">
-							<Alert variant="success">
-								Your data export has been downloaded.
-							</Alert>
+							<Alert variant="success">Your data export has been downloaded.</Alert>
 							<Button
 								onClick={handleDownloadExport}
 								icon={<Download className="w-4 h-4" />}
@@ -449,22 +468,24 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 					<Alert variant="warning" className="mb-4">
 						<p className="font-semibold mb-1">This action is permanent</p>
 						<p className="text-xs opacity-90">
-							Your account will be anonymized and all personal data erased.
-							This includes your profile, sessions, avatars, friend requests,
-							and notifications. This cannot be undone.
+							Your account will be anonymized and all personal data erased. This
+							includes your profile, sessions, avatars, friend requests, and
+							notifications. This cannot be undone.
 						</p>
 					</Alert>
 
 					<div aria-live="assertive" aria-atomic="true" className="sr-only">
-						{deleteFlow.step === 'awaiting_email' && 'Check your email for a confirmation link.'}
-						{deleteFlow.step === 'done' && 'Your account has been deleted. Redirecting.'}
+						{deleteFlow.step === 'awaiting_email' &&
+							'Check your email for a confirmation link.'}
+						{deleteFlow.step === 'done' &&
+							'Your account has been deleted. Redirecting.'}
 					</div>
 
 					{deleteFlow.error && (
 						<Alert
 							variant="error"
 							dismissable
-							onDismiss={() => setDeleteFlow(prev => ({ ...prev, error: null }))}
+							onDismiss={() => setDeleteFlow((prev) => ({ ...prev, error: null }))}
 							className="mb-3"
 						>
 							{deleteFlow.error}
@@ -473,7 +494,9 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 					{deleteFlow.step === 'idle' && (
 						<Button
-							onClick={() => setDeleteFlow(prev => ({ ...prev, step: 'credentials' }))}
+							onClick={() =>
+								setDeleteFlow((prev) => ({ ...prev, step: 'credentials' }))
+							}
 							variant="danger"
 							icon={<Trash2 className="w-4 h-4" />}
 						>
@@ -486,14 +509,16 @@ export default function DataPrivacyModal({ onClose }: DataPrivacyModalProps) {
 
 					{deleteFlow.step === 'awaiting_email' && renderAwaitingEmail('delete')}
 
-					{(deleteFlow.step === 'confirm_credentials' || deleteFlow.step === 'executing') &&
+					{(deleteFlow.step === 'confirm_credentials' ||
+						deleteFlow.step === 'executing') &&
 						renderCredentialInputs('delete', 'execute')}
 
 					{deleteFlow.step === 'done' && (
 						<Alert variant="success">
 							<p className="font-semibold mb-1">Account deleted</p>
 							<p className="text-xs opacity-90">
-								Your account has been permanently deleted. You will be redirected shortly.
+								Your account has been permanently deleted. You will be redirected
+								shortly.
 							</p>
 						</Alert>
 					)}

--- a/frontend/tests/fixtures/users.ts
+++ b/frontend/tests/fixtures/users.ts
@@ -10,6 +10,7 @@ export function createMockUser(overrides?: Partial<User>): User {
 		totp_confirmed_at: null,
 		description: '',
 		tos_accepted_at: '2025-01-01T00:00:00Z',
+		email_confirmed_at: null,
 		...overrides,
 	};
 }

--- a/frontend/tests/integration/home/Home.test.tsx
+++ b/frontend/tests/integration/home/Home.test.tsx
@@ -194,6 +194,26 @@ describe('Home', () => {
 		});
 	});
 
+	describe('privacy & data modal', () => {
+		it('opens DataPrivacyModal from menu', async () => {
+			const user = userEvent.setup();
+			renderHome();
+
+			await waitFor(() => {
+				expect(screen.getByText('Player Dashboard')).toBeInTheDocument();
+			});
+
+			// Open menu
+			await user.click(screen.getByRole('button', { name: /TestUser/i }));
+			await user.click(screen.getByText('Privacy & Data'));
+
+			await waitFor(() => {
+				expect(screen.getByRole('heading', { name: 'Export My Data' })).toBeInTheDocument();
+				expect(screen.getByRole('heading', { name: 'Delete My Account' })).toBeInTheDocument();
+			});
+		});
+	});
+
 	describe('manage sessions', () => {
 		it('calls onSessions from menu', async () => {
 			const user = userEvent.setup();

--- a/frontend/tests/integration/modals/DataPrivacyModal.test.tsx
+++ b/frontend/tests/integration/modals/DataPrivacyModal.test.tsx
@@ -1,0 +1,542 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, userEvent } from '../../helpers/render';
+import DataPrivacyModal from '../../../src/components/modals/DataPrivacyModal';
+import { server } from '../../helpers/msw-handlers';
+import { http, HttpResponse } from 'msw';
+import { createMockUser, createMockAuthResponse } from '../../fixtures/users';
+import { createMockApiError } from '../../fixtures/errors';
+import type { GdprInitiateResponse, DataExport } from '../../../src/api/types';
+
+const mockInitiateResponse: GdprInitiateResponse = {
+	token: 'dGVzdC10b2tlbi0xMjM0NTY3ODkwYWJjZGVm',
+	email_confirmation_required: false,
+	expires_at: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+};
+
+const mockInitiateWithEmail: GdprInitiateResponse = {
+	...mockInitiateResponse,
+	email_confirmation_required: true,
+};
+
+const mockDataExport: DataExport = {
+	exported_at: new Date().toISOString(),
+	user: {
+		id: 1,
+		email: 'test@example.com',
+		nickname: 'TestUser',
+		totp_enabled: false,
+		totp_confirmed_at: null,
+		created_at: '2024-01-01T00:00:00Z',
+		description: '',
+		tos_accepted_at: '2025-01-01T00:00:00Z',
+		email_confirmed_at: null,
+		pending_email_change: null,
+	},
+	sessions: [],
+	friend_requests: [],
+	notifications: [],
+	avatar_large_base64: null,
+	avatar_small_base64: null,
+};
+
+describe('DataPrivacyModal', () => {
+	const mockOnClose = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const renderModal = (userOverrides = {}) => {
+		const authResponse = createMockAuthResponse(userOverrides);
+
+		server.use(
+			http.get('/api/user/me', () => {
+				return HttpResponse.json(authResponse);
+			}),
+		);
+
+		return render(<DataPrivacyModal onClose={mockOnClose} />);
+	};
+
+	// ── Rendering & initial state ─────────────────────────────
+
+	describe('initial state', () => {
+		it('renders modal with title', async () => {
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+		});
+
+		it('shows both sections', async () => {
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByRole('heading', { name: 'Export My Data' })).toBeInTheDocument();
+				expect(screen.getByRole('heading', { name: 'Delete My Account' })).toBeInTheDocument();
+			});
+		});
+
+		it('does not show password inputs initially', async () => {
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+		});
+
+		it('closes on escape key', async () => {
+			const user = userEvent.setup();
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			await user.keyboard('{Escape}');
+			expect(mockOnClose).toHaveBeenCalled();
+		});
+
+		it('has correct dialog role and aria-modal', () => {
+			renderModal();
+
+			const dialog = screen.getByRole('dialog');
+			expect(dialog).toHaveAttribute('aria-modal', 'true');
+		});
+	});
+
+	// ── Export flow ────────────────────────────────────────────
+
+	describe('export flow', () => {
+		it('clicking export button reveals password input', async () => {
+			const user = userEvent.setup();
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Click the Export button (in the idle state, it says "Export My Data")
+			const exportButtons = screen.getAllByText('Export My Data');
+			// The button is the second one (first is the heading text)
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			expect(screen.getByLabelText('Password')).toBeInTheDocument();
+		});
+
+		it('shows MFA input when user has 2FA enabled', async () => {
+			const user = userEvent.setup();
+			renderModal({ totp_enabled: true });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			expect(screen.getByLabelText('Authentication Code')).toBeInTheDocument();
+		});
+
+		it('shows validation error on empty password', async () => {
+			const user = userEvent.setup();
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			await user.click(screen.getByText('Continue'));
+
+			expect(screen.getByText('Password is required.')).toBeInTheDocument();
+		});
+
+		it('shows MFA validation error on invalid format', async () => {
+			const user = userEvent.setup();
+			renderModal({ totp_enabled: true });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.type(screen.getByLabelText('Authentication Code'), 'abc');
+			await user.click(screen.getByText('Continue'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Invalid recovery code format.')).toBeInTheDocument();
+			});
+		});
+
+		it('successful initiation without email shows re-enter credentials', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.post('/api/user/export-my-data', () => {
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			await waitFor(() => {
+				expect(screen.getByText(/Re-enter your credentials/)).toBeInTheDocument();
+			});
+		});
+
+		it('successful initiation with email shows check email step', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.post('/api/user/export-my-data', () => {
+					return HttpResponse.json(mockInitiateWithEmail);
+				}),
+			);
+
+			renderModal({ email_confirmed_at: '2024-01-01T00:00:00Z' });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Check your email')).toBeInTheDocument();
+			});
+		});
+
+		it('successful execution shows download button', async () => {
+			const user = userEvent.setup();
+
+			let callCount = 0;
+			server.use(
+				http.post('/api/user/export-my-data', ({ request }) => {
+					const url = new URL(request.url);
+					if (url.searchParams.has('token')) {
+						return HttpResponse.json(mockDataExport);
+					}
+					callCount++;
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Step 1: Initiate
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			// Step 2: Execute
+			await waitFor(() => {
+				expect(screen.getByText(/Re-enter your credentials/)).toBeInTheDocument();
+			});
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Download My Data'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Your data export has been downloaded.')).toBeInTheDocument();
+				expect(screen.getByText('Download Again')).toBeInTheDocument();
+			});
+		});
+	});
+
+	// ── Delete flow ───────────────────────────────────────────
+
+	describe('delete flow', () => {
+		it('clicking delete button reveals password input', async () => {
+			const user = userEvent.setup();
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const deleteButtons = screen.getAllByText('Delete My Account');
+			await user.click(deleteButtons[deleteButtons.length - 1]);
+
+			expect(screen.getAllByLabelText('Password').length).toBeGreaterThan(0);
+		});
+
+		it('shows nickname confirmation in execute step', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.delete('/api/user/delete-my-account', () => {
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal({ nickname: 'TestPlayer' });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Initiate
+			const deleteButtons = screen.getAllByText('Delete My Account');
+			await user.click(deleteButtons[deleteButtons.length - 1]);
+			await user.type(screen.getAllByLabelText('Password')[0], 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			// Should show nickname confirmation
+			await waitFor(() => {
+				expect(screen.getByText(/Type your username "TestPlayer" to confirm/)).toBeInTheDocument();
+			});
+		});
+
+		it('execute button disabled when nickname does not match', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.delete('/api/user/delete-my-account', () => {
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal({ nickname: 'TestPlayer' });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Initiate
+			const deleteButtons = screen.getAllByText('Delete My Account');
+			await user.click(deleteButtons[deleteButtons.length - 1]);
+			await user.type(screen.getAllByLabelText('Password')[0], 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			await waitFor(() => {
+				expect(screen.getByText(/Type your username/)).toBeInTheDocument();
+			});
+
+			// Type wrong nickname
+			await user.type(screen.getByPlaceholderText('TestPlayer'), 'WrongName');
+
+			const permanentDeleteBtn = screen.getByText('Permanently Delete My Account');
+			expect(permanentDeleteBtn).toBeDisabled();
+		});
+
+		it('successful deletion calls clearAuth', async () => {
+			const user = userEvent.setup();
+
+			let callCount = 0;
+			server.use(
+				http.delete('/api/user/delete-my-account', ({ request }) => {
+					const url = new URL(request.url);
+					if (url.searchParams.has('token')) {
+						return new HttpResponse(null, { status: 204 });
+					}
+					callCount++;
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal({ nickname: 'TestUser' });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Initiate
+			const deleteButtons = screen.getAllByText('Delete My Account');
+			await user.click(deleteButtons[deleteButtons.length - 1]);
+			await user.type(screen.getAllByLabelText('Password')[0], 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			// Execute
+			await waitFor(() => {
+				expect(screen.getByText(/Type your username/)).toBeInTheDocument();
+			});
+
+			await user.type(screen.getByPlaceholderText('TestUser'), 'TestUser');
+			await user.type(screen.getAllByLabelText('Password')[0], 'mypassword123');
+			await user.click(screen.getByText('Permanently Delete My Account'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Account deleted')).toBeInTheDocument();
+			});
+		});
+	});
+
+	// ── Error handling ────────────────────────────────────────
+
+	describe('error handling', () => {
+		it('shows server error on wrong password', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.post('/api/user/export-my-data', () => {
+					return HttpResponse.json(
+						{ error: createMockApiError({ code: 401, brief: 'InvalidCredentials', detail: 'Invalid password' }) },
+						{ status: 401 },
+					);
+				}),
+			);
+
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			await user.type(screen.getByLabelText('Password'), 'wrongpassword');
+			await user.click(screen.getByText('Continue'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Invalid password')).toBeInTheDocument();
+			});
+		});
+
+		it('resets to idle on token expired', async () => {
+			const user = userEvent.setup();
+
+			let callCount = 0;
+			server.use(
+				http.post('/api/user/export-my-data', ({ request }) => {
+					const url = new URL(request.url);
+					if (url.searchParams.has('token')) {
+						return HttpResponse.json(
+							{ error: createMockApiError({ code: 410, brief: 'TokenExpired' }) },
+							{ status: 410 },
+						);
+					}
+					callCount++;
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Initiate
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			// Execute (will get token expired)
+			await waitFor(() => {
+				expect(screen.getByText(/Re-enter your credentials/)).toBeInTheDocument();
+			});
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Download My Data'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Your request has expired. Please start over.')).toBeInTheDocument();
+			});
+
+			// Should be back to idle — "Export My Data" button visible again
+			const exportBtnsAfter = screen.getAllByText('Export My Data');
+			expect(exportBtnsAfter.length).toBeGreaterThan(1); // heading + button
+		});
+
+		it('routes back to awaiting email on EmailConfirmationPending', async () => {
+			const user = userEvent.setup();
+
+			server.use(
+				http.post('/api/user/export-my-data', ({ request }) => {
+					const url = new URL(request.url);
+					if (url.searchParams.has('token')) {
+						return HttpResponse.json(
+							{ error: createMockApiError({ code: 403, brief: 'EmailConfirmationPending' }) },
+							{ status: 403 },
+						);
+					}
+					return HttpResponse.json(mockInitiateResponse);
+				}),
+			);
+
+			renderModal();
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Initiate
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Continue'));
+
+			// Execute (will get email confirmation pending)
+			await waitFor(() => {
+				expect(screen.getByText(/Re-enter your credentials/)).toBeInTheDocument();
+			});
+
+			await user.type(screen.getByLabelText('Password'), 'mypassword123');
+			await user.click(screen.getByText('Download My Data'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Check your email')).toBeInTheDocument();
+			});
+		});
+	});
+
+	// ── Accessibility ─────────────────────────────────────────
+
+	describe('accessibility', () => {
+		it('sections have aria-labelledby', () => {
+			renderModal();
+
+			const exportSection = screen.getByLabelText('Export My Data');
+			expect(exportSection).toBeInTheDocument();
+
+			const deleteSection = screen.getByLabelText('Delete My Account');
+			expect(deleteSection).toBeInTheDocument();
+		});
+
+		it('all inputs have associated labels', async () => {
+			const user = userEvent.setup();
+			renderModal({ totp_enabled: true });
+
+			await waitFor(() => {
+				expect(screen.getByText('Privacy & Data')).toBeInTheDocument();
+			});
+
+			// Open export credentials
+			const exportButtons = screen.getAllByText('Export My Data');
+			await user.click(exportButtons[exportButtons.length - 1]);
+
+			expect(screen.getByLabelText('Password')).toBeInTheDocument();
+			expect(screen.getByLabelText('Authentication Code')).toBeInTheDocument();
+		});
+	});
+});

--- a/frontend/tests/integration/modals/DataPrivacyModal.test.tsx
+++ b/frontend/tests/integration/modals/DataPrivacyModal.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, userEvent } from '../../helpers/render';
 import DataPrivacyModal from '../../../src/components/modals/DataPrivacyModal';
 import { server } from '../../helpers/msw-handlers';
 import { http, HttpResponse } from 'msw';
-import { createMockUser, createMockAuthResponse } from '../../fixtures/users';
+import { createMockAuthResponse } from '../../fixtures/users';
 import { createMockApiError } from '../../fixtures/errors';
 import type { GdprInitiateResponse, DataExport } from '../../../src/api/types';
 
@@ -232,14 +232,12 @@ describe('DataPrivacyModal', () => {
 		it('successful execution shows download button', async () => {
 			const user = userEvent.setup();
 
-			let callCount = 0;
 			server.use(
 				http.post('/api/user/export-my-data', ({ request }) => {
 					const url = new URL(request.url);
 					if (url.searchParams.has('token')) {
 						return HttpResponse.json(mockDataExport);
 					}
-					callCount++;
 					return HttpResponse.json(mockInitiateResponse);
 				}),
 			);
@@ -350,14 +348,12 @@ describe('DataPrivacyModal', () => {
 		it('successful deletion calls clearAuth', async () => {
 			const user = userEvent.setup();
 
-			let callCount = 0;
 			server.use(
 				http.delete('/api/user/delete-my-account', ({ request }) => {
 					const url = new URL(request.url);
 					if (url.searchParams.has('token')) {
 						return new HttpResponse(null, { status: 204 });
 					}
-					callCount++;
 					return HttpResponse.json(mockInitiateResponse);
 				}),
 			);
@@ -424,7 +420,6 @@ describe('DataPrivacyModal', () => {
 		it('resets to idle on token expired', async () => {
 			const user = userEvent.setup();
 
-			let callCount = 0;
 			server.use(
 				http.post('/api/user/export-my-data', ({ request }) => {
 					const url = new URL(request.url);
@@ -434,7 +429,6 @@ describe('DataPrivacyModal', () => {
 							{ status: 410 },
 						);
 					}
-					callCount++;
 					return HttpResponse.json(mockInitiateResponse);
 				}),
 			);


### PR DESCRIPTION
Builds on top of #132 
adds frontend for the GDPR compliance.

- API layer (types.ts, user.ts, error.ts): 7 new TypeScript interfaces matching
the backend Rust structs exactly, 2 API functions (deleteMyAccount,
exportMyData) using query params for the token (matching backend's QueryParam),
and 4 GDPR error brief codes.
- DataPrivacyModal: A state-machine-driven modal with two
independent flows (export + delete), each with 7 possible states. Credentials
stored in useRef (not state) for security. Nickname confirmation adds deliberate
 friction before irreversible deletion. aria-live regions announce state
transitions to screen readers.
- Home.tsx: Single dropdown entry "Privacy & Data" with ShieldCheck icon, placed
 between "Email Confirmation" and the logout separator — giving it first-class
visibility without disrupting the existing menu flow.
- integration tests covering: rendering, export flow (idle → credentials →
execute → download), delete flow (with nickname confirmation), error handling
(token expired, email pending, wrong password), and accessibility (dialog role,
labels, headings).
