### PR TITLE
fix(docker/prod): allow privileged port binding in production container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,13 @@ services:
     # all incoming connections to be the same (the one of the docker bridge),
     # which breaks rate limiting and session ip identification
     network_mode: host
+    user: "0:0"
+    entrypoint: ["/app/transcendence-backend"]
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - DAC_OVERRIDE
     # ports:
     #   - "80:80"
     #   - "443:443/tcp"


### PR DESCRIPTION
## Summary
- run backend process as root in prod compose and bypass entrypoint privilege drop
- add explicit linux capabilities for privileged bind and data directory writes
- keep host networking behavior unchanged for correct client IP visibility

## Test Plan
- cargo test --all-targets (backend) passes locally
- verified on VPS that backend starts without bind permission panic