### PR TITLE
Feat/game trailing animation

### DIFF
--- a/docs/superpowers/specs/2026-04-06-trailing-animation-design.md
+++ b/docs/superpowers/specs/2026-04-06-trailing-animation-design.md
@@ -1,0 +1,157 @@
+# Trailing Animation Design — Swing Trails
+
+**Date:** 2026-04-06
+**Branch:** feat/game-trailing-animation
+**Scope:** Frontend only (BabylonJS) — no backend changes required
+
+---
+
+## Summary
+
+Add a ribbon trail effect to character weapon swings. The trail follows the weapon tip for the last 50% of the swing arc, fades from transparent to bright, and tapers from zero width at the tail to full width at the tip. Colors are per character class.
+
+---
+
+## Visual Specification
+
+- **Style:** Ribbon / arc trail (flat translucent ribbon stretching behind the weapon tip)
+- **Duration:** Rolling window covering the last 50% of `swing_progress` (not time-based — uses progress units for accuracy across varying server tick rates)
+- **Width:** Tapers from `maxWidth` (~0.15 world units) at the newest point to 0 at the oldest
+- **Alpha:** Fades from 0 (oldest/tail) to ~0.85 (newest/tip)
+- **Colors per class:**
+  - Knight: base `rgb(79, 195, 247)` (ice blue) → tip `rgb(255, 255, 255)` (white/silver)
+  - Rogue: base `rgb(102, 187, 106)` (toxic green) → tip `rgb(200, 255, 200)` (light green)
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/game/SwingTrail.ts` | **New** — self-contained trail class |
+| `frontend/src/game/AnimatedCharacter.ts` | Add `trail` field, `initTrail()`, `getWeaponTipMesh()` |
+| `frontend/src/game/characterConfigs.ts` | Add `trailColor` field to `CharacterConfig` |
+| `frontend/src/components/GameBoard/SimpleGameClient.tsx` | Call `initTrail()` after load; call `trail.update()` each frame |
+
+---
+
+## SwingTrail Class
+
+**File:** `frontend/src/game/SwingTrail.ts`
+
+Single responsibility: given a weapon tip mesh and `swing_progress` each frame, render a ribbon trail.
+
+### Constructor config
+
+```ts
+{
+  baseColor: Color3   // tail end color
+  tipColor: Color3    // weapon-end color (bright)
+  maxWidth: number    // ribbon width at newest point (~0.15 world units)
+}
+```
+
+### Public API
+
+```ts
+update(weaponTipMesh: AbstractMesh, swingProgress: number): void
+dispose(): void
+```
+
+### Internal state
+
+```ts
+history: Array<{ pos: Vector3, progress: number }>
+ribbon: Mesh | null   // updatable BabylonJS ribbon mesh
+lastProgress: number  // detects swing reset (prev > 0, current == 0)
+```
+
+### update() logic
+
+1. **`swingProgress > 0` (swing active):**
+   - Sample weapon tip world position, push `{ pos, progress }` to history
+   - Prune entries where `swingProgress - entry.progress >= 0.5` (keep last 50% of arc)
+   - If `history.length >= 3`: build/update ribbon with width taper and vertex color gradient
+   - If ribbon doesn't exist yet: create with `updatable: true`; otherwise update via `CreateRibbon({ instance })`
+
+2. **`swingProgress == 0` and `lastProgress > 0` (swing just ended):**
+   - Clear history, set `ribbon.isVisible = false` (keep mesh alive for reuse next swing)
+
+3. **`swingProgress == 0` (idle):** no-op
+
+### Ribbon geometry
+
+The ribbon is built from two parallel paths (top/bottom edges) offset perpendicular to the direction of travel, with width at each point proportional to its recency `(1 - age)` where `age = (currentProgress - entry.progress) / 0.5`.
+
+Color gradient is applied via `StandardMaterial` with `vertexColorsEnabled = true` and a `VertexData` colors array updated each frame alongside the ribbon paths. Alpha blending enabled via `material.alpha` and `hasVertexAlpha = true`.
+
+---
+
+## CharacterConfig changes
+
+Add to `CharacterConfig` interface:
+
+```ts
+trailColor: {
+  base: [number, number, number]  // RGB 0–255
+  tip:  [number, number, number]  // RGB 0–255
+}
+```
+
+Knight and Rogue configs updated with their respective colors.
+
+---
+
+## AnimatedCharacter changes
+
+```ts
+trail: SwingTrail | null = null
+
+// Called once after loadCharacter() completes
+initTrail(scene: Scene, config: CharacterConfig): void
+
+// Returns the right-hand weapon mesh (equipment slot 0, first non-__root__ mesh)
+getWeaponTipMesh(): AbstractMesh | null
+```
+
+`dispose()` updated to also call `this.trail?.dispose()`.
+
+---
+
+## SimpleGameClient integration
+
+**After `loadCharacter(char, config)`:**
+```ts
+char.initTrail(scene, config)
+```
+
+**Inside the render loop, per-character snapshot update:**
+```ts
+const weaponTip = char.getWeaponTipMesh()
+char.trail?.update(weaponTip, charData.swing_progress)
+```
+
+This covers both local and remote characters. `update()` handles the idle case internally (no-op when `swing_progress == 0` and was already 0).
+
+---
+
+## Data flow
+
+```
+Server snapshot
+  └─ CharacterSnapshot.swing_progress (0.0 → 1.0)
+       └─ SimpleGameClient.processSnapshot() / render loop
+            └─ AnimatedCharacter.trail.update(weaponTipMesh, swingProgress)
+                 ├─ Record tip world position + progress
+                 ├─ Prune history (keep last 50% of progress)
+                 └─ Rebuild updatable ribbon mesh
+```
+
+---
+
+## Out of scope
+
+- Per-chain-stage trail intensity variation (future enhancement)
+- Crit flash / hit spark effects
+- Trail for ability skills (MeleeAOE)
+- Backend changes

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -293,8 +293,6 @@ class GameClient {
 				if (this.localCharacter) {
 					this.localCharacter.setPosition(this.position);
 					this.localCharacter.setRotation(char.yaw);
-					if (char.swing_progress > 0)
-						console.log('[Trail] swing_progress=', char.swing_progress, 'trail=', this.localCharacter.trail);
 					this.localCharacter.trail?.update(
 						this.localCharacter.getWeaponWorldPos(),
 						char.swing_progress,
@@ -552,13 +550,10 @@ class GameClient {
 		for (const event of events) {
 			switch (event.type) {
 				case 'Death':
-					console.debug('[Game] Death: killer=%d victim=%d', event.killer, event.victim);
 					break;
 				case 'Damage':
-					console.debug('[Game] Damage: %d → %d (%.1f)', event.attacker, event.victim, event.damage);
 					break;
 				case 'Spawn':
-					console.debug('[Game] Spawn: player=%d', event.player_id);
 					this.getChar(event.player_id)?.playAnimation(AnimationNames.spawn, false);
 					if (event.player_id === this.localPlayerID) {
 						this.localIsDead = false;
@@ -568,7 +563,6 @@ class GameClient {
 					}
 					break;
 				case 'StateChange':
-					console.debug('[Game] StateChange: player=%d state=%d', event.player_id, event.state);
 					break;
 				case 'AttackStarted': {
 					const config = this.characterConfigMap.get(event.player_id);
@@ -603,7 +597,6 @@ class GameClient {
 					break;
 				}
 				case 'MatchEnd':
-					console.debug('[Game] MatchEnd');
 					break;
 			}
 		}
@@ -703,10 +696,6 @@ export default function SimpleGameClient({
 			ambientLight.groundColor = new BABYLON.Color3(0.2, 0.2, 0.2);
 
 			scene.onReadyObservable.addOnce(() => {
-				console.log(
-					'[Scene] cameras:',
-					scene.cameras.map((c) => `${c.name} (${c.getClassName()})`),
-				);
 				scene.activeCamera = camera;
 			});
 

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -270,6 +270,7 @@ class GameClient {
 		this.localCharacter = new AnimatedCharacter(this.scene);
 		await loadCharacter(this.localCharacter, this.characterConfig);
 		this.characterConfigMap.set(this.localPlayerID, this.characterConfig);
+		this.localCharacter.initTrail(this.characterConfig);
 
 		this.localCharacter.setPosition(this.position);
 		this.localCharacter.playAnimation(AnimationNames.spawn, false);
@@ -292,6 +293,12 @@ class GameClient {
 				if (this.localCharacter) {
 					this.localCharacter.setPosition(this.position);
 					this.localCharacter.setRotation(char.yaw);
+					if (char.swing_progress > 0)
+						console.log('[Trail] swing_progress=', char.swing_progress, 'trail=', this.localCharacter.trail);
+					this.localCharacter.trail?.update(
+						this.localCharacter.getWeaponWorldPos(),
+						char.swing_progress,
+					);
 				}
 
 				if (this.localHealthFill) {
@@ -352,6 +359,10 @@ class GameClient {
 					this.remoteJumpStates.set(char.player_id, newJumpState);
 					const remoteConfig = this.characterConfigMap.get(char.player_id);
 					if (remoteConfig) this.updateSnapshotFallbackAnimation(char.player_id, remoteChar, char, remoteConfig, newJumpState);
+					remoteChar.trail?.update(
+						remoteChar.getWeaponWorldPos(),
+						char.swing_progress,
+					);
 
 					const bar = this.enemyBars.get(char.player_id);
 					if (bar) {
@@ -400,6 +411,7 @@ class GameClient {
 				CHARACTER_CONFIGS[DEFAULT_CHARACTER];
 			this.characterConfigMap.set(playerID, config);
 			await loadCharacter(remoteChar, config);
+			remoteChar.initTrail(config);
 
 			if (playerID === this.localPlayerID) {
 				remoteChar.dispose();

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -685,15 +685,6 @@ export default function SimpleGameClient({
 			camera.minZ = 0.1;
 			camera.maxZ = 500;
 
-			// Ambient fill light so vertex-color materials (trail ribbon) are visible.
-			// HemisphericLight is shadow-free and doesn't conflict with baked scene lighting.
-			const ambientLight = new BABYLON.HemisphericLight(
-				'ambientFill',
-				new BABYLON.Vector3(0, 1, 0),
-				scene,
-			);
-			ambientLight.intensity = 0.2;
-			ambientLight.groundColor = new BABYLON.Color3(0.2, 0.2, 0.2);
 
 			scene.onReadyObservable.addOnce(() => {
 				scene.activeCamera = camera;

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -692,6 +692,16 @@ export default function SimpleGameClient({
 			camera.minZ = 0.1;
 			camera.maxZ = 500;
 
+			// Ambient fill light so vertex-color materials (trail ribbon) are visible.
+			// HemisphericLight is shadow-free and doesn't conflict with baked scene lighting.
+			const ambientLight = new BABYLON.HemisphericLight(
+				'ambientFill',
+				new BABYLON.Vector3(0, 1, 0),
+				scene,
+			);
+			ambientLight.intensity = 0.4;
+			ambientLight.groundColor = new BABYLON.Color3(0.2, 0.2, 0.2);
+
 			scene.onReadyObservable.addOnce(() => {
 				console.log(
 					'[Scene] cameras:',

--- a/frontend/src/components/GameBoard/SimpleGameClient.tsx
+++ b/frontend/src/components/GameBoard/SimpleGameClient.tsx
@@ -692,7 +692,7 @@ export default function SimpleGameClient({
 				new BABYLON.Vector3(0, 1, 0),
 				scene,
 			);
-			ambientLight.intensity = 0.4;
+			ambientLight.intensity = 0.2;
 			ambientLight.groundColor = new BABYLON.Color3(0.2, 0.2, 0.2);
 
 			scene.onReadyObservable.addOnce(() => {

--- a/frontend/src/game/AnimatedCharacter.ts
+++ b/frontend/src/game/AnimatedCharacter.ts
@@ -169,11 +169,13 @@ export class AnimatedCharacter {
 	}
 
 	initTrail(config: CharacterConfig): void {
-		const { base, tip, maxWidth } = config.trailColor;
+		const { base, tip, maxWidth, tailOpacity, tipOpacity } = config.trailColor;
 		this.trail = new SwingTrail(this.scene, {
 			baseColor: new Color3(base[0] / 255, base[1] / 255, base[2] / 255),
 			tipColor:  new Color3(tip[0]  / 255, tip[1]  / 255, tip[2]  / 255),
 			maxWidth,
+			tailOpacity,
+			tipOpacity,
 		});
 	}
 

--- a/frontend/src/game/AnimatedCharacter.ts
+++ b/frontend/src/game/AnimatedCharacter.ts
@@ -1,12 +1,14 @@
 import type { AbstractMesh, AnimationGroup, Scene, Observer } from '@babylonjs/core';
-import { SceneLoader, TransformNode, Vector3 } from '@babylonjs/core';
+import { Color3, SceneLoader, TransformNode, Vector3 } from '@babylonjs/core';
 import '@babylonjs/loaders/glTF';
 import type { CharacterConfig } from './characterConfigs';
+import { SwingTrail } from './SwingTrail';
 
 export class AnimatedCharacter {
 	public rootNode: TransformNode;
 	public meshes: AbstractMesh[] = [];
 	public animations: Map<string, AnimationGroup> = new Map();
+	public trail: SwingTrail | null = null;
 	public currentAnimation: AnimationGroup | null = null;
 	private currentAnimationName: string = '';
 	private scene: Scene;
@@ -14,6 +16,7 @@ export class AnimatedCharacter {
 	private skeleton: any = null;
 	private blendObserver: Observer<Scene> | null = null;
 	private fadingOutAnim: AnimationGroup | null = null;
+	private equipmentMeshes: AbstractMesh[] = [];
 
 	constructor(scene: Scene) {
 		this.scene = scene;
@@ -80,6 +83,7 @@ export class AnimatedCharacter {
 			if (rotation) mesh.rotation.copyFrom(rotation);
 			else mesh.rotation.set(0, 0, 0);
 			mesh.scaling.set(1, 1, 1);
+			this.equipmentMeshes.push(mesh);
 		});
 	}
 
@@ -164,6 +168,42 @@ export class AnimatedCharacter {
 		}
 	}
 
+	initTrail(config: CharacterConfig): void {
+		const { base, tip, maxWidth } = config.trailColor;
+		this.trail = new SwingTrail(this.scene, {
+			baseColor: new Color3(base[0] / 255, base[1] / 255, base[2] / 255),
+			tipColor:  new Color3(tip[0]  / 255, tip[1]  / 255, tip[2]  / 255),
+			maxWidth,
+		});
+		console.log('[Trail] initTrail OK, trail=', this.trail);
+	}
+
+	// Returns the world-space position of the right-hand weapon tip.
+	// Uses the weapon mesh bounding box to find the tip (farthest point from grip).
+	// Falls back to the handslot.r bone position if no equipment mesh is loaded yet.
+	getWeaponWorldPos(): Vector3 | null {
+		if (this.equipmentMeshes.length > 0) {
+			const mesh = this.equipmentMeshes[0];
+			const bb = mesh.getBoundingInfo().boundingBox;
+			const grip = mesh.getAbsolutePosition();
+			// The tip is whichever extreme of the AABB is farthest from the grip origin.
+			const toMax = bb.maximumWorld.subtract(grip).length();
+			const toMin = bb.minimumWorld.subtract(grip).length();
+			return (toMax >= toMin ? bb.maximumWorld : bb.minimumWorld).clone();
+		}
+		// Fallback: read grip position from handslot.r bone.
+		if (!this.skeleton) return null;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const bone = this.skeleton.bones.find((b: any) => b.name === 'handslot.r');
+		if (!bone) return null;
+		const node = bone.getTransformNode?.();
+		if (node) return node.getAbsolutePosition().clone();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const m = (bone as any).getAbsoluteTransform?.()?.m;
+		if (m) return new Vector3(m[12], m[13], m[14]);
+		return null;
+	}
+
 	setPosition(pos: Vector3): void {
 		this.rootNode.position.copyFrom(pos);
 	}
@@ -174,7 +214,9 @@ export class AnimatedCharacter {
 
 	dispose(): void {
 		this.cancelBlend();
+		this.trail?.dispose();
 		this.animations.forEach((anim) => anim.stop());
+		this.equipmentMeshes.forEach((mesh) => mesh.dispose());
 		this.meshes.forEach((mesh) => mesh.dispose());
 		this.rootNode.dispose();
 	}

--- a/frontend/src/game/AnimatedCharacter.ts
+++ b/frontend/src/game/AnimatedCharacter.ts
@@ -175,7 +175,6 @@ export class AnimatedCharacter {
 			tipColor:  new Color3(tip[0]  / 255, tip[1]  / 255, tip[2]  / 255),
 			maxWidth,
 		});
-		console.log('[Trail] initTrail OK, trail=', this.trail);
 	}
 
 	// Returns the world-space position of the right-hand weapon tip.

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -2,9 +2,11 @@ import { Color3, MeshBuilder, StandardMaterial, Vector3, VertexBuffer } from '@b
 import type { Mesh, Scene } from '@babylonjs/core';
 
 export interface SwingTrailConfig {
-  baseColor: Color3; // tail end — dim/transparent
-  tipColor: Color3;  // weapon end — bright
-  maxWidth: number;  // ribbon half-width at newest point (world units)
+  baseColor: Color3;   // tail end color (oldest point)
+  tipColor: Color3;    // weapon end color (newest point, most visible)
+  maxWidth: number;    // ribbon half-width at the weapon end (world units)
+  tailOpacity: number; // opacity at the tail end — see TrailColor.tailOpacity
+  tipOpacity: number;  // opacity at the weapon end — see TrailColor.tipOpacity
 }
 
 interface TrailPoint {
@@ -111,7 +113,7 @@ export class SwingTrail {
       const r = this.config.baseColor.r + (this.config.tipColor.r - this.config.baseColor.r) * age;
       const g = this.config.baseColor.g + (this.config.tipColor.g - this.config.baseColor.g) * age;
       const b = this.config.baseColor.b + (this.config.tipColor.b - this.config.baseColor.b) * age;
-      const a = age * 0.85;
+      const a = this.config.tailOpacity + (this.config.tipOpacity - this.config.tailOpacity) * age;
 
       // path1[i] → vertex i
       colors[i * 4]     = r; colors[i * 4 + 1] = g;

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -1,4 +1,4 @@
-import { Color3, MeshBuilder, StandardMaterial, Vector3 } from '@babylonjs/core';
+import { Color3, MeshBuilder, StandardMaterial, Vector3, VertexBuffer } from '@babylonjs/core';
 import type { Mesh, Scene } from '@babylonjs/core';
 
 export interface SwingTrailConfig {
@@ -30,8 +30,8 @@ export class SwingTrail {
 
     this.material = new StandardMaterial('swingTrailMat', scene);
     this.material.backFaceCulling = false;
-    this.material.disableLighting = true;
-    this.material.emissiveColor = new Color3(1, 0, 0); // DEBUG: solid red
+    this.material.hasVertexAlpha = true;
+    this.material.specularColor = Color3.Black(); // no specular highlight on the ribbon
   }
 
   update(worldPos: Vector3 | null, swingProgress: number): void {
@@ -97,12 +97,34 @@ export class SwingTrail {
       path2.push(new Vector3(pos.x + dz * halfWidth, pos.y, pos.z - dx * halfWidth));
     }
 
-    // Recreate ribbon mesh (path count changes every frame due to rolling window)
+    // Recreate ribbon mesh (path count changes every frame due to rolling window).
+    // dispose(false, false) skips children and — critically — skips the shared material,
+    // so we don't destroy the material object we're about to reassign.
     this.ribbon?.dispose(false, false);
     this.ribbon = MeshBuilder.CreateRibbon('swingTrail', {
       pathArray: [path1, path2],
     }, this.scene) as Mesh;
+    this.ribbon.hasVertexAlpha = true;
     this.ribbon.material = this.material;
+
+    // Vertex color gradient: transparent tail → bright tip
+    // BabylonJS ribbon vertex layout: [path1[0..N-1], path2[0..N-1]]
+    const colors = new Float32Array(n * 2 * 4);
+    for (let i = 0; i < n; i++) {
+      const age = i / (n - 1);
+      const r = this.config.baseColor.r + (this.config.tipColor.r - this.config.baseColor.r) * age;
+      const g = this.config.baseColor.g + (this.config.tipColor.g - this.config.baseColor.g) * age;
+      const b = this.config.baseColor.b + (this.config.tipColor.b - this.config.baseColor.b) * age;
+      const a = age * 0.85;
+
+      // path1[i] → vertex i
+      colors[i * 4]     = r; colors[i * 4 + 1] = g;
+      colors[i * 4 + 2] = b; colors[i * 4 + 3] = a;
+      // path2[i] → vertex N+i
+      colors[(n + i) * 4]     = r; colors[(n + i) * 4 + 1] = g;
+      colors[(n + i) * 4 + 2] = b; colors[(n + i) * 4 + 3] = a;
+    }
+    this.ribbon.setVerticesData(VertexBuffer.ColorKind, colors);
     console.log('[Trail] ribbon verts=', this.ribbon.getTotalVertices(), 'n=', n);
   }
 

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -1,0 +1,115 @@
+import { Color3, MeshBuilder, StandardMaterial, Vector3 } from '@babylonjs/core';
+import type { Mesh, Scene } from '@babylonjs/core';
+
+export interface SwingTrailConfig {
+  baseColor: Color3; // tail end — dim/transparent
+  tipColor: Color3;  // weapon end — bright
+  maxWidth: number;  // ribbon half-width at newest point (world units)
+}
+
+interface TrailPoint {
+  pos: Vector3;
+  progress: number;
+}
+
+// Show the last 50% of the swing arc (progress units, not time)
+const TAIL_FRACTION = 0.5;
+const MIN_POINTS = 3;
+
+export class SwingTrail {
+  private config: SwingTrailConfig;
+  private scene: Scene;
+  private history: TrailPoint[] = [];
+  private ribbon: Mesh | null = null;
+  private material: StandardMaterial;
+  private lastProgress = 0;
+
+  constructor(scene: Scene, config: SwingTrailConfig) {
+    this.scene = scene;
+    this.config = config;
+
+    this.material = new StandardMaterial('swingTrailMat', scene);
+    this.material.backFaceCulling = false;
+    this.material.disableLighting = true;
+    this.material.emissiveColor = new Color3(1, 0, 0); // DEBUG: solid red
+  }
+
+  update(worldPos: Vector3 | null, swingProgress: number): void {
+    console.log('[Trail] update called: progress=', swingProgress, 'pos=', worldPos?.toString());
+    const wasActive = this.lastProgress > 0;
+    this.lastProgress = swingProgress;
+
+    if (swingProgress <= 0) {
+      if (wasActive) {
+        this.history = [];
+        if (this.ribbon) this.ribbon.isVisible = false;
+      }
+      return;
+    }
+
+    if (!worldPos) {
+      console.warn('[SwingTrail] no weapon position — trail skipped');
+      return;
+    }
+
+    this.history.push({ pos: worldPos, progress: swingProgress });
+
+    // Prune entries outside the rolling window (oldest 50% of arc)
+    const cutoff = swingProgress - TAIL_FRACTION;
+    let pruneCount = 0;
+    while (pruneCount < this.history.length && this.history[pruneCount].progress < cutoff) {
+      pruneCount++;
+    }
+    if (pruneCount > 0) this.history.splice(0, pruneCount);
+
+    if (this.history.length < MIN_POINTS) return;
+
+    this.rebuildRibbon();
+  }
+
+  private rebuildRibbon(): void {
+    const n = this.history.length;
+
+    // Build two parallel paths offset perpendicular to the swing arc in XZ.
+    // A horizontal ribbon is clearly visible from the isometric camera (35° elevation).
+    const path1: Vector3[] = [];
+    const path2: Vector3[] = [];
+
+    for (let i = 0; i < n; i++) {
+      const age = i / (n - 1); // 0 = oldest, 1 = newest
+      const halfWidth = this.config.maxWidth * age;
+      const { pos } = this.history[i];
+
+      // Direction of travel in XZ; use neighbour on endpoints
+      let dx = 0, dz = 1;
+      if (i < n - 1) {
+        dx = this.history[i + 1].pos.x - pos.x;
+        dz = this.history[i + 1].pos.z - pos.z;
+      } else if (i > 0) {
+        dx = pos.x - this.history[i - 1].pos.x;
+        dz = pos.z - this.history[i - 1].pos.z;
+      }
+      const len = Math.sqrt(dx * dx + dz * dz);
+      if (len > 0.0001) { dx /= len; dz /= len; }
+
+      // Perpendicular in XZ: (-dz, 0, dx)
+      path1.push(new Vector3(pos.x - dz * halfWidth, pos.y, pos.z + dx * halfWidth));
+      path2.push(new Vector3(pos.x + dz * halfWidth, pos.y, pos.z - dx * halfWidth));
+    }
+
+    // Recreate ribbon mesh (path count changes every frame due to rolling window)
+    this.ribbon?.dispose(false, false);
+    this.ribbon = MeshBuilder.CreateRibbon('swingTrail', {
+      pathArray: [path1, path2],
+    }, this.scene) as Mesh;
+    this.ribbon.material = this.material;
+    console.log('[Trail] ribbon verts=', this.ribbon.getTotalVertices(), 'n=', n);
+  }
+
+  dispose(): void {
+    this.ribbon?.dispose();
+    this.material.dispose();
+    this.ribbon = null;
+    this.history = [];
+  }
+}

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -25,6 +25,11 @@ export class SwingTrail {
   private ribbon: Mesh | null = null;
   private material: StandardMaterial;
   private lastProgress = 0;
+  // Guard against collecting trail points before the skeleton has been evaluated
+  // at least once in idle state. Without this, the first call after async character
+  // load may use stale bone transforms (previous render frame's idle pose) while
+  // the character is mid-attack, producing a glitchy trail segment from origin.
+  private seenIdle = false;
 
   constructor(scene: Scene, config: SwingTrailConfig) {
     this.scene = scene;
@@ -42,6 +47,7 @@ export class SwingTrail {
     this.lastProgress = swingProgress;
 
     if (swingProgress <= 0) {
+      this.seenIdle = true;
       if (wasActive) {
         this.history = [];
         if (this.ribbon) this.ribbon.isVisible = false;
@@ -49,7 +55,7 @@ export class SwingTrail {
       return;
     }
 
-    if (!worldPos) return;
+    if (!worldPos || !this.seenIdle) return;
 
     this.history.push({ pos: worldPos, progress: swingProgress });
 

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -52,30 +52,32 @@ export class SwingTrail {
   }
 
   private prewarmShader(): void {
-    // Place the warmup ribbon at the world origin so it is inside the camera
-    // frustum. BabylonJS only calls isReadyForMesh() for frustum-visible meshes,
-    // so a ribbon outside the frustum (e.g. at y=-9999) never triggers compilation.
-    // All vertex alphas are 0 → fully transparent, not visible to the player.
+    // Create a tiny invisible ribbon to force BabylonJS to compile the
+    // StandardMaterial shader (position + ColorKind + hasVertexAlpha) ahead of
+    // the first real swing. Without this, WEBGL_parallel_shader_compile makes
+    // newly-created ribbons invisible for several frames while the GPU compiles.
+    //
+    // alwaysSelectAsActiveMesh bypasses frustum culling so the shader compiles
+    // regardless of where the camera is — spawn positions may be far from origin.
     const p = [new Vector3(0, 0, 0), new Vector3(0.0001, 0, 0)];
     const warmup = MeshBuilder.CreateRibbon('_swingTrailWarm', {
       pathArray: [p, p],
     }, this.scene) as Mesh;
     warmup.hasVertexAlpha = true;
     warmup.material = this.material;
+    warmup.alwaysSelectAsActiveMesh = true;
     // Vertex colors (all zeros = alpha 0) must be present so the shader defines
     // (VERTEXCOLOR / VERTEXALPHA) match those used by the real ribbon.
     warmup.setVerticesData(VertexBuffer.ColorKind, new Float32Array(2 * 2 * 4));
 
-    // Keep the warmup alive for several frames so async compilation (via
-    // WEBGL_parallel_shader_compile in WebGL2) has time to finish before the
-    // first real ribbon appears. Character loading takes several seconds, so
-    // 10 frames is more than enough.
-    let framesLeft = 10;
-    const obs = this.scene.onAfterRenderObservable.add(() => {
-      if (--framesLeft <= 0) {
-        warmup.dispose(false, false);
-        this.scene.onAfterRenderObservable.remove(obs);
-      }
+    // Wait until the shader is actually compiled before disposing the warmup
+    // mesh. forceCompilationAsync resolves once the GPU has finished compiling
+    // the effect for this mesh's vertex layout, so we don't rely on guessing
+    // a frame count.
+    this.material.forceCompilationAsync(warmup).then(() => {
+      warmup.dispose(false, false);
+    }).catch(() => {
+      warmup.dispose(false, false);
     });
   }
 

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -40,6 +40,43 @@ export class SwingTrail {
     this.material.hasVertexAlpha = true;
     this.material.disableLighting = true;
     this.material.emissiveColor = new Color3(0.6, 0.6, 0.6); // vertex RGB × 0.4 = 40% brightness
+
+    // Pre-warm the StandardMaterial shader so it is compiled before the first
+    // attack. BabylonJS (WebGL2 + WEBGL_parallel_shader_compile) compiles
+    // effects asynchronously, leaving newly-created meshes invisible for
+    // several frames while the GPU finishes. By rendering one dummy ribbon
+    // with the same vertex-buffer layout (position + ColorKind + hasVertexAlpha)
+    // the compilation starts immediately, and the cached effect is ready long
+    // before the player can trigger their first swing.
+    this.prewarmShader();
+  }
+
+  private prewarmShader(): void {
+    // Place the warmup ribbon at the world origin so it is inside the camera
+    // frustum. BabylonJS only calls isReadyForMesh() for frustum-visible meshes,
+    // so a ribbon outside the frustum (e.g. at y=-9999) never triggers compilation.
+    // All vertex alphas are 0 → fully transparent, not visible to the player.
+    const p = [new Vector3(0, 0, 0), new Vector3(0.0001, 0, 0)];
+    const warmup = MeshBuilder.CreateRibbon('_swingTrailWarm', {
+      pathArray: [p, p],
+    }, this.scene) as Mesh;
+    warmup.hasVertexAlpha = true;
+    warmup.material = this.material;
+    // Vertex colors (all zeros = alpha 0) must be present so the shader defines
+    // (VERTEXCOLOR / VERTEXALPHA) match those used by the real ribbon.
+    warmup.setVerticesData(VertexBuffer.ColorKind, new Float32Array(2 * 2 * 4));
+
+    // Keep the warmup alive for several frames so async compilation (via
+    // WEBGL_parallel_shader_compile in WebGL2) has time to finish before the
+    // first real ribbon appears. Character loading takes several seconds, so
+    // 10 frames is more than enough.
+    let framesLeft = 10;
+    const obs = this.scene.onAfterRenderObservable.add(() => {
+      if (--framesLeft <= 0) {
+        warmup.dispose(false, false);
+        this.scene.onAfterRenderObservable.remove(obs);
+      }
+    });
   }
 
   update(worldPos: Vector3 | null, swingProgress: number): void {

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -35,7 +35,6 @@ export class SwingTrail {
   }
 
   update(worldPos: Vector3 | null, swingProgress: number): void {
-    console.log('[Trail] update called: progress=', swingProgress, 'pos=', worldPos?.toString());
     const wasActive = this.lastProgress > 0;
     this.lastProgress = swingProgress;
 
@@ -47,10 +46,7 @@ export class SwingTrail {
       return;
     }
 
-    if (!worldPos) {
-      console.warn('[SwingTrail] no weapon position — trail skipped');
-      return;
-    }
+    if (!worldPos) return;
 
     this.history.push({ pos: worldPos, progress: swingProgress });
 
@@ -125,7 +121,6 @@ export class SwingTrail {
       colors[(n + i) * 4 + 2] = b; colors[(n + i) * 4 + 3] = a;
     }
     this.ribbon.setVerticesData(VertexBuffer.ColorKind, colors);
-    console.log('[Trail] ribbon verts=', this.ribbon.getTotalVertices(), 'n=', n);
   }
 
   dispose(): void {

--- a/frontend/src/game/SwingTrail.ts
+++ b/frontend/src/game/SwingTrail.ts
@@ -33,7 +33,8 @@ export class SwingTrail {
     this.material = new StandardMaterial('swingTrailMat', scene);
     this.material.backFaceCulling = false;
     this.material.hasVertexAlpha = true;
-    this.material.specularColor = Color3.Black(); // no specular highlight on the ribbon
+    this.material.disableLighting = true;
+    this.material.emissiveColor = new Color3(0.6, 0.6, 0.6); // vertex RGB × 0.4 = 40% brightness
   }
 
   update(worldPos: Vector3 | null, swingProgress: number): void {

--- a/frontend/src/game/characterConfigs.ts
+++ b/frontend/src/game/characterConfigs.ts
@@ -23,9 +23,11 @@ export interface AnimationEntry {
 }
 
 export interface TrailColor {
-	base: [number, number, number]; // RGB 0–255, tail end (transparent)
-	tip: [number, number, number];  // RGB 0–255, weapon end (bright)
-	maxWidth: number;               // ribbon half-width in world units
+	base: [number, number, number]; // RGB 0–255, color at the tail end (oldest point)
+	tip: [number, number, number];  // RGB 0–255, color at the weapon end (newest point, most visible)
+	maxWidth: number;               // ribbon half-width in world units at the weapon end
+	tailOpacity: number;            // opacity of the tail end (0.0 = invisible, 1.0 = fully opaque) — controls how visible the base color is
+	tipOpacity: number;             // opacity of the weapon end (0.0 = invisible, 1.0 = fully opaque) — keep below 1.0 for a translucent feel
 }
 
 export interface CharacterConfig {
@@ -66,7 +68,7 @@ export const CHARACTER_CONFIGS: Record<CharacterChoice, CharacterConfig> = {
 			{ name: 'Melee_1H_Attack_Jump_Chop' },   // skill1
 			{ name: 'Melee_1H_Attack_Chop' },         // skill2 — placeholder
 		],
-		trailColor: { base: [79, 195, 247], tip: [255, 255, 255], maxWidth: 0.3 },
+		trailColor: { base: [220, 235, 255], tip: [100, 165, 255], maxWidth: 0.3, tailOpacity: 0.13, tipOpacity: 0.85 },
 	},
 	Rogue: {
 		label: 'Rogue',
@@ -83,6 +85,6 @@ export const CHARACTER_CONFIGS: Record<CharacterChoice, CharacterConfig> = {
 		runAnimation:     { name: 'Running_B', speed: 1.2 },
 		attackAnimations: [{ name: 'Melee_Dualwield_Attack_Chop', speed: 1.4 }],  // placeholder
 		skillAnimations:  [{ name: 'Melee_Dualwield_Attack_Chop', speed: 1.4 }],  // placeholder
-		trailColor: { base: [102, 187, 106], tip: [200, 255, 200], maxWidth: 0.3 },
+		trailColor: { base: [102, 187, 106], tip: [200, 255, 200], maxWidth: 0.3, tailOpacity: 0.13, tipOpacity: 0.85 },
 	},
 };

--- a/frontend/src/game/characterConfigs.ts
+++ b/frontend/src/game/characterConfigs.ts
@@ -22,6 +22,12 @@ export interface AnimationEntry {
 	speed?: number;  // playback speed multiplier (default 1.0)
 }
 
+export interface TrailColor {
+	base: [number, number, number]; // RGB 0–255, tail end (transparent)
+	tip: [number, number, number];  // RGB 0–255, weapon end (bright)
+	maxWidth: number;               // ribbon half-width in world units
+}
+
 export interface CharacterConfig {
 	label: string;
 	model: string;
@@ -34,6 +40,7 @@ export interface CharacterConfig {
 	runAnimation:     AnimationEntry;
 	attackAnimations: AnimationEntry[];  // [stage0, stage1, stage2, ...] — index = chain stage
 	skillAnimations:  AnimationEntry[];  // [skill1anim, skill2anim] — index = slot - 1
+	trailColor: TrailColor;
 }
 
 export const CHARACTER_CONFIGS: Record<CharacterChoice, CharacterConfig> = {
@@ -59,6 +66,7 @@ export const CHARACTER_CONFIGS: Record<CharacterChoice, CharacterConfig> = {
 			{ name: 'Melee_1H_Attack_Jump_Chop' },   // skill1
 			{ name: 'Melee_1H_Attack_Chop' },         // skill2 — placeholder
 		],
+		trailColor: { base: [79, 195, 247], tip: [255, 255, 255], maxWidth: 0.3 },
 	},
 	Rogue: {
 		label: 'Rogue',
@@ -75,5 +83,6 @@ export const CHARACTER_CONFIGS: Record<CharacterChoice, CharacterConfig> = {
 		runAnimation:     { name: 'Running_B', speed: 1.2 },
 		attackAnimations: [{ name: 'Melee_Dualwield_Attack_Chop', speed: 1.4 }],  // placeholder
 		skillAnimations:  [{ name: 'Melee_Dualwield_Attack_Chop', speed: 1.4 }],  // placeholder
+		trailColor: { base: [102, 187, 106], tip: [200, 255, 200], maxWidth: 0.3 },
 	},
 };


### PR DESCRIPTION
feat: add swing trail ribbon effect for weapon attacks

  Adds a visual ribbon trail that follows the weapon tip during melee attack
  swings, giving combat more visual feedback and weight.

  - Implement SwingTrail system using BabylonJS ribbon meshes with a rolling
  window that tracks weapon world position during swing_progress
  - Per-character trail color configuration (base/tip RGB, opacity, width)
  defined in characterConfigs
  - Vertex color gradient from transparent tail to bright weapon tip with
  configurable opacity
  - Self-lit material (disableLighting + emissiveColor) so trails are visible
  regardless of scene lighting
  - Trail renders for both local and remote players using swing_progress from
  server snapshots
  - Pre-warm shader compilation via forceCompilationAsync to eliminate
  first-attack flicker across all spawn positions
  
 [game-frontend] hit/slash visuals - Closes #160