### PR TITLE
Feat/game stamina system hud

### DIFF
--- a/backend/src/game/ffi.rs
+++ b/backend/src/game/ffi.rs
@@ -54,6 +54,8 @@ mod bridge {
         ability2_cooldown: f32,
         swing_progress: f32,
         is_grounded: bool,
+        stamina: f32,
+        max_stamina: f32,
     }
 
     struct GameStateSnapshot {
@@ -211,6 +213,8 @@ pub struct CharacterSnapshot {
     pub ability2_cooldown: f32,
     pub swing_progress: f32,
     pub is_grounded: bool,
+    pub stamina: f32,
+    pub max_stamina: f32,
 }
 
 impl From<bridge::CharacterSnapshot> for CharacterSnapshot {
@@ -237,6 +241,8 @@ impl From<bridge::CharacterSnapshot> for CharacterSnapshot {
             ability2_cooldown: c.ability2_cooldown,
             swing_progress: c.swing_progress,
             is_grounded: c.is_grounded,
+            stamina: c.stamina,
+            max_stamina: c.max_stamina,
         }
     }
 }

--- a/docs/superpowers/plans/2026-04-10-stamina-system.md
+++ b/docs/superpowers/plans/2026-04-10-stamina-system.md
@@ -1,0 +1,994 @@
+# Stamina System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a server-authoritative stamina resource system that gates sprinting, attacking, skills, and jumping, with scaled regen and exhaustion mechanics.
+
+**Architecture:** New `Stamina` ECS component mirroring the `Health` pattern, a dedicated `StaminaSystem` running in `lateUpdate` for regen, and integration points in `CombatSystem` (attack/skill gating) and `CharacterControllerSystem` (sprint/jump gating). Snapshot pipeline carries stamina to frontend through the existing C++→Rust→TypeScript path.
+
+**Tech Stack:** C++17 (game-core ECS), Rust (backend FFI bridge), TypeScript (frontend types)
+
+**Spec:** `docs/superpowers/specs/2026-04-10-stamina-system-design.md`
+
+---
+
+## File Map
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `game-core/src/components/Stamina.hpp` | Stamina ECS component — data + convenience methods |
+| `game-core/src/systems/StaminaSystem.hpp` | Stamina regen system — owns exhaustion detection + scaled regen |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `game-core/src/Skills.hpp` | Add `staminaCost` field to `AttackStage` and `SkillDefinition` |
+| `game-core/src/CharacterPreset.hpp` | Add `StaminaPreset` struct, add `stamina` field to `CharacterPreset` |
+| `game-core/src/Presets.hpp` | Populate Knight stamina values, add `staminaCost` to attack stages and skills |
+| `game-core/src/core/World.hpp` | Include `StaminaSystem.hpp`, register system, attach component on entity creation, restore on respawn |
+| `game-core/src/systems/CombatSystem.hpp` | Include `Stamina.hpp`, add stamina checks before attacks/skills, consume on completion |
+| `game-core/src/systems/CharacterControllerSystem.hpp` | Include `Stamina.hpp`, add sprint drain, jump cost, sprint disable on exhaustion |
+| `game-core/src/ArenaGame.hpp` | Add `stamina`/`maxStamina` to `CharacterSnapshot`, populate in `createSnapshot()` |
+| `game-core/src/cxx_bridge.cpp` | Add stamina fields to bridge snapshot mapping |
+| `backend/src/game/ffi.rs` | Add `stamina`/`max_stamina` to CXX bridge struct, Rust struct, and `From` impl |
+| `frontend/src/game/types.ts` | Add `stamina`/`max_stamina` to `CharacterSnapshot` interface |
+
+---
+
+### Task 1: Add `staminaCost` to `AttackStage` and `SkillDefinition`
+
+**Files:**
+- Modify: `game-core/src/Skills.hpp:17-31`
+
+- [ ] **Step 1: Add `staminaCost` to `SkillDefinition`**
+
+In `game-core/src/Skills.hpp`, add after line 20 (`float castDuration = 0.0f;`):
+
+```cpp
+	float staminaCost  = 0.0f;  // stamina consumed when cast completes
+```
+
+- [ ] **Step 2: Add `staminaCost` to `AttackStage`**
+
+In the same file, add after line 30 (`float attackAngle = 1.047f;`):
+
+```cpp
+	float staminaCost  = 0.0f;  // stamina consumed when this swing completes
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `make build` (or the project's build command)
+Expected: Compiles cleanly. Default `0.0f` means all existing code is unaffected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add game-core/src/Skills.hpp
+git commit -m "feat(game): add staminaCost field to AttackStage and SkillDefinition"
+```
+
+---
+
+### Task 2: Add `StaminaPreset` and wire into `CharacterPreset`
+
+**Files:**
+- Modify: `game-core/src/CharacterPreset.hpp:6-53`
+
+- [ ] **Step 1: Add `StaminaPreset` struct**
+
+In `game-core/src/CharacterPreset.hpp`, add after the `ColliderPreset` struct (after line 36, before `CombatPreset`):
+
+```cpp
+	struct StaminaPreset {
+		float maxStamina;          // total stamina pool
+		float baseRegenRate;       // max regen per second (at 100% stamina)
+		float drainDelaySeconds;   // seconds of no regen after full depletion
+		float sprintCostPerSec;    // stamina consumed per second while sprinting
+		float jumpCost;            // flat stamina consumed per jump
+	};
+```
+
+- [ ] **Step 2: Add `stamina` field to `CharacterPreset`**
+
+In the same file, add `StaminaPreset stamina;` to the `CharacterPreset` struct, after `collider` and before `combat`:
+
+```cpp
+	struct CharacterPreset {
+		HealthPreset   health;
+		MovementPreset movement;
+		ColliderPreset collider;
+		StaminaPreset  stamina;    // NEW
+		CombatPreset   combat;
+	};
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `make build`
+Expected: Build fails — `Presets.hpp` does not initialize the new `stamina` field in KNIGHT. This is expected and fixed in Task 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add game-core/src/CharacterPreset.hpp
+git commit -m "feat(game): add StaminaPreset struct and wire into CharacterPreset"
+```
+
+---
+
+### Task 3: Populate Knight preset with stamina values
+
+**Files:**
+- Modify: `game-core/src/Presets.hpp:10-57`
+
+- [ ] **Step 1: Add Knight `StaminaPreset` values**
+
+In `game-core/src/Presets.hpp`, insert the `.stamina` block after `.collider` (after line 35) and before `.combat`:
+
+```cpp
+		.stamina = {
+			.maxStamina        = 100.0f,
+			.baseRegenRate     = 40.0f,    // effective: 4.0/s (10% floor) to 40.0/s
+			.drainDelaySeconds = 1.5f,     // pause after full depletion
+			.sprintCostPerSec  = 15.0f,    // ~6.6s of continuous sprint
+			.jumpCost          = 8.0f,     // ~12 jumps from full
+		},
+```
+
+- [ ] **Step 2: Add `staminaCost` to attack chain stages**
+
+In the same file, update the three `AttackStage` initializers to include `staminaCost`:
+
+Stage 0 (line 43-44) — add `.staminaCost=10.0f` after `.chainWindow=0.6f`:
+```cpp
+			// Stage 0 — diagonal slice: quick opener
+			{ .damageMultiplier=0.8f, .range=2.0f, .duration=0.45f,
+			  .movementMultiplier=0.0f, .chainWindow=0.6f, .staminaCost=10.0f },
+```
+
+Stage 1 (line 46-47) — add `.staminaCost=15.0f` after `.chainWindow=0.5f`:
+```cpp
+			// Stage 1 — horizontal slice: mid combo
+			{ .damageMultiplier=0.9f, .range=2.2f, .duration=0.50f,
+			  .movementMultiplier=0.0f, .chainWindow=0.5f, .staminaCost=15.0f },
+```
+
+Stage 2 (line 49-50) — add `.staminaCost=25.0f` after `.chainWindow=0.0f`:
+```cpp
+			// Stage 2 — stab: heavy finisher, chain resets (chainWindow=0)
+			{ .damageMultiplier=1.6f, .range=1.8f, .duration=0.60f,
+			  .movementMultiplier=0.0f, .chainWindow=0.0f, .staminaCost=25.0f },
+```
+
+- [ ] **Step 3: Add `staminaCost` to skill definitions**
+
+Update skill1 (line 52-53) and skill2 (line 54-55):
+
+```cpp
+			.skill1 = { .params = MeleeAOE{ .range=2.5f, .movementMultiplier=0.0f, .dmgMultiplier=1.8f },
+			            .cooldown=5.0f, .castDuration=0.7f, .staminaCost=20.0f },
+			.skill2 = { .params = MeleeAOE{ .range=2.0f, .movementMultiplier=0.7f, .dmgMultiplier=1.5f },
+			            .cooldown=10.0f, .castDuration=0.5f, .staminaCost=30.0f },
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly. The Knight preset now has all stamina values.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add game-core/src/Presets.hpp
+git commit -m "feat(game): populate Knight preset with stamina costs and regen values"
+```
+
+---
+
+### Task 4: Create `Stamina` component
+
+**Files:**
+- Create: `game-core/src/components/Stamina.hpp`
+
+- [ ] **Step 1: Write the Stamina component**
+
+Create `game-core/src/components/Stamina.hpp`:
+
+```cpp
+#pragma once
+
+#include "../CharacterPreset.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace ArenaGame {
+namespace Components {
+
+// =============================================================================
+// Stamina - Resource pool for physical actions (sprint, attack, skill, jump)
+// =============================================================================
+// Pure data component with convenience methods. Mirrors Health pattern.
+//
+// Regen formula (applied by StaminaSystem in lateUpdate):
+//   effectiveRate = max(baseRegenRate * current/maximum, baseRegenRate * 0.10)
+//   → smooth curve: more stamina = faster regen, 10% floor prevents near-zero stall
+//
+// Exhaustion: when current hits 0, drainDelayTimer starts. No regen until it
+// expires. Prevents stutter-loop of drain→regen→drain.
+//
+// Consumption is done by CombatSystem (attacks/skills) and
+// CharacterControllerSystem (sprint/jump). This component only stores state.
+// =============================================================================
+
+struct Stamina {
+	// Pool
+	float current;
+	float maximum;
+
+	// Regen
+	float baseRegenRate;      // max regen/s at 100% stamina
+	float drainDelay;         // configured pause duration after full depletion
+	float drainDelayTimer;    // runtime countdown (0 = not exhausted or delay expired)
+
+	// State
+	bool exhausted;           // true from depletion until drainDelayTimer expires
+
+	// Per-class costs (copied from StaminaPreset at spawn)
+	float sprintCostPerSec;   // continuous drain while sprinting
+	float jumpCost;           // flat cost per jump
+
+	// ── Constructors ────────────────────────────────────────────────────
+
+	Stamina()
+		: current(100.0f)
+		, maximum(100.0f)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	explicit Stamina(float maxStamina)
+		: current(maxStamina)
+		, maximum(maxStamina)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	// ── Queries ─────────────────────────────────────────────────────────
+
+	bool canAfford(float cost) const {
+		return current >= cost;
+	}
+
+	bool isExhausted() const {
+		return exhausted;
+	}
+
+	bool isFull() const {
+		return current >= maximum;
+	}
+
+	float getPercent() const {
+		return maximum > 0.0f ? (current / maximum) : 0.0f;
+	}
+
+	// ── Mutation ─────────────────────────────────────────────────────────
+
+	void consume(float amount) {
+		current = std::max(0.0f, current - amount);
+	}
+
+	void recover(float amount) {
+		current = std::min(current + amount, maximum);
+	}
+
+	void restore() {
+		current = maximum;
+		exhausted = false;
+		drainDelayTimer = 0.0f;
+	}
+
+	// ── Factory ─────────────────────────────────────────────────────────
+
+	static Stamina createFromPreset(const StaminaPreset& preset) {
+		Stamina s;
+		s.maximum          = preset.maxStamina;
+		s.current          = s.maximum;
+		s.baseRegenRate    = preset.baseRegenRate;
+		s.drainDelay       = preset.drainDelaySeconds;
+		s.drainDelayTimer  = 0.0f;
+		s.exhausted        = false;
+		s.sprintCostPerSec = preset.sprintCostPerSec;
+		s.jumpCost         = preset.jumpCost;
+		return s;
+	}
+};
+
+} // namespace Components
+} // namespace ArenaGame
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly. No other file includes Stamina.hpp yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game-core/src/components/Stamina.hpp
+git commit -m "feat(game): add Stamina ECS component"
+```
+
+---
+
+### Task 5: Create `StaminaSystem`
+
+**Files:**
+- Create: `game-core/src/systems/StaminaSystem.hpp`
+
+- [ ] **Step 1: Write the StaminaSystem**
+
+Create `game-core/src/systems/StaminaSystem.hpp`:
+
+```cpp
+#pragma once
+
+#include "System.hpp"
+#include "../components/Stamina.hpp"
+#include "../components/CharacterController.hpp"
+#include "../components/CombatController.hpp"
+#include "../components/Health.hpp"
+#include "../../entt/entt.hpp"
+#include <algorithm>
+
+namespace ArenaGame {
+
+// =============================================================================
+// StaminaSystem - Stamina regeneration (runs in lateUpdate)
+// =============================================================================
+// Sole owner of regen logic. Does NOT consume stamina — that is done by
+// CombatSystem (attacks/skills) and CharacterControllerSystem (sprint/jump).
+//
+// Responsibilities:
+//   1. Detect full depletion → set exhausted flag + start drain delay timer
+//   2. Tick drain delay timer during exhaustion
+//   3. Clear exhaustion when delay expires
+//   4. Apply scaled regen when player is not actively consuming stamina
+//
+// Regen formula:
+//   effectiveRate = max(baseRegenRate * (current / maximum), baseRegenRate * 0.10)
+//   → 10% floor prevents infinitely slow recovery near zero
+//
+// Runs in lateUpdate (after CharacterControllerSystem in earlyUpdate and
+// CombatSystem in update) so all consumption for the current frame is already
+// applied before regen ticks.
+// =============================================================================
+
+class StaminaSystem : public System {
+public:
+	StaminaSystem() = default;
+
+	void lateUpdate(float deltaTime) override;
+	const char* getName() const override { return "StaminaSystem"; }
+	bool needsLateUpdate() const override { return true; }
+	bool needsUpdate() const override { return false; }
+};
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+inline void StaminaSystem::lateUpdate(float deltaTime) {
+	auto view = m_registry->view<
+		Components::Stamina,
+		Components::CharacterController,
+		Components::CombatController,
+		Components::Health
+	>();
+
+	view.each([&](Components::Stamina& stamina,
+				  Components::CharacterController& controller,
+				  Components::CombatController& combat,
+				  Components::Health& health) {
+
+		// 1. Dead players don't regen
+		if (!health.isAlive()) return;
+
+		// 2. Detect full depletion → enter exhaustion
+		if (stamina.current <= 0.0f && !stamina.exhausted) {
+			stamina.exhausted = true;
+			stamina.drainDelayTimer = stamina.drainDelay;
+		}
+
+		// 3. Tick drain delay during exhaustion
+		if (stamina.exhausted) {
+			stamina.drainDelayTimer -= deltaTime;
+			if (stamina.drainDelayTimer <= 0.0f) {
+				stamina.exhausted = false;
+				stamina.drainDelayTimer = 0.0f;
+			} else {
+				return;  // no regen during drain delay
+			}
+		}
+
+		// 4. No regen while actively spending stamina
+		if (controller.isSprinting) return;
+		if (combat.isAttacking) return;
+		if (combat.isAbility1Casting()) return;
+		if (combat.isAbility2Casting()) return;
+
+		// 5. Scaled regen with 10% minimum floor
+		float ratio = stamina.current / stamina.maximum;
+		float effectiveRate = stamina.baseRegenRate * ratio;
+		effectiveRate = std::max(effectiveRate, stamina.baseRegenRate * 0.10f);
+
+		stamina.current = std::min(stamina.current + effectiveRate * deltaTime, stamina.maximum);
+	});
+}
+
+} // namespace ArenaGame
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly. Not registered yet, so it doesn't run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add game-core/src/systems/StaminaSystem.hpp
+git commit -m "feat(game): add StaminaSystem with scaled regen and exhaustion"
+```
+
+---
+
+### Task 6: Register `StaminaSystem` and attach `Stamina` component to entities
+
+**Files:**
+- Modify: `game-core/src/core/World.hpp:1-26` (includes), `161-198` (initialize), `287-301` (createActor), `421-440` (respawnPlayer)
+
+- [ ] **Step 1: Add includes**
+
+In `game-core/src/core/World.hpp`, add after line 7 (`#include "../components/Health.hpp"`):
+
+```cpp
+#include "../components/Stamina.hpp"
+```
+
+And add after line 23 (`#include "../systems/GameModeSystem.hpp"`):
+
+```cpp
+#include "../systems/StaminaSystem.hpp"
+```
+
+- [ ] **Step 2: Register StaminaSystem in `World::initialize()`**
+
+In the `initialize()` method, add after line 167 (`auto gameModeSystem = ...`):
+
+```cpp
+	auto staminaSystem = std::make_unique<StaminaSystem>();
+```
+
+Add after line 176 (`gameModeSystem->setRegistry(&m_registry);`):
+
+```cpp
+	staminaSystem->setRegistry(&m_registry);
+```
+
+Add after line 184 (`gameModeSystem->setGameManager(m_gameManager);`):
+
+```cpp
+	staminaSystem->setGameManager(m_gameManager);
+```
+
+Add after line 198 (`m_systemManager.addSystem(std::move(gameModeSystem));`):
+
+```cpp
+	m_systemManager.addSystem(std::move(staminaSystem));
+```
+
+- [ ] **Step 3: Attach Stamina component in `createActor()`**
+
+In `createActor()`, add after line 298 (`m_registry.emplace<Components::Health>(entity, ...)`):
+
+```cpp
+	m_registry.emplace<Components::Stamina>(entity, Components::Stamina::createFromPreset(preset.stamina));
+```
+
+- [ ] **Step 4: Restore stamina on respawn**
+
+In `respawnPlayer()`, add after line 431 (`if (health) health->revive();`):
+
+```cpp
+	auto* stamina = m_registry.try_get<Components::Stamina>(player);
+	if (stamina) stamina->restore();
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly. `StaminaSystem` is now registered and `Stamina` component is attached to all actors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add game-core/src/core/World.hpp
+git commit -m "feat(game): register StaminaSystem and attach Stamina component to entities"
+```
+
+---
+
+### Task 7: Integrate stamina into `CombatSystem`
+
+**Files:**
+- Modify: `game-core/src/systems/CombatSystem.hpp:1-26` (includes), `215-276` (processInputAttacks), `409-434` (handleSwingEnd), `436-465` (tickSkillSlot)
+
+- [ ] **Step 1: Add Stamina include**
+
+In `game-core/src/systems/CombatSystem.hpp`, add after line 7 (`#include "../components/Health.hpp"`):
+
+```cpp
+#include "../components/Stamina.hpp"
+```
+
+- [ ] **Step 2: Add Stamina to the `processInputAttacks` view and lambda**
+
+Update the view at line 220 to include `Components::Stamina`:
+
+```cpp
+	auto view = m_registry->view<CharacterController, CombatController, Health, Transform, PhysicsBody, Stamina>();
+```
+
+Update the lambda signature at lines 222-227 to include `Stamina& stamina`:
+
+```cpp
+	view.each([&](entt::entity entity,
+				  CharacterController& charcon,
+				  CombatController&    comcon,
+				  Health&              health,
+				  Transform&           trans,
+				  PhysicsBody&         physics,
+				  Stamina&             stamina) {
+```
+
+- [ ] **Step 3: Add stamina gating to skill2**
+
+At line 248, wrap the existing `wantsSkill2` block with a stamina check. Replace:
+
+```cpp
+		if (wantsSkill2 && comcon.canUseAbility2()) {
+```
+
+With:
+
+```cpp
+		if (wantsSkill2 && comcon.canUseAbility2() && stamina.canAfford(comcon.ability2.staminaCost)) {
+```
+
+- [ ] **Step 4: Add stamina gating to skill1**
+
+At line 254, replace:
+
+```cpp
+		} else if (wantsSkill1 && comcon.canUseAbility1()) {
+```
+
+With:
+
+```cpp
+		} else if (wantsSkill1 && comcon.canUseAbility1() && stamina.canAfford(comcon.ability1.staminaCost)) {
+```
+
+- [ ] **Step 5: Add stamina gating to attacks**
+
+At line 260, replace:
+
+```cpp
+		} else if (wantsAttack && comcon.canPerformAttack()) {
+```
+
+With:
+
+```cpp
+		} else if (wantsAttack && comcon.canPerformAttack() && stamina.canAfford(comcon.currentStage().staminaCost)) {
+```
+
+- [ ] **Step 6: Discard unaffordable buffered actions**
+
+After line 241 (`comcon.bufferedAction = CombatController::BufferedAction::None;`), add a stamina check that discards the buffered action if it became unaffordable:
+
+```cpp
+		// Discard buffered action if stamina is insufficient
+		if (toFire == CombatController::BufferedAction::Attack
+				&& !stamina.canAfford(comcon.currentStage().staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill1
+				&& !stamina.canAfford(comcon.ability1.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill2
+				&& !stamina.canAfford(comcon.ability2.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+```
+
+- [ ] **Step 7: Consume stamina in `handleSwingEnd`**
+
+In `handleSwingEnd()`, add stamina consumption before `combat.advanceChain()`. At line 421 (inside the `if (combat.hitPending)` block, after `const AttackStage& stage = combat.currentStage();`), add:
+
+```cpp
+			// Consume stamina for this swing stage (read BEFORE advanceChain)
+			if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+				stamina->consume(stage.staminaCost);
+```
+
+The full modified block (lines 418-427) should read:
+
+```cpp
+	if (combat.hitPending) {
+		if (health.isAlive()) {
+			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
+			const AttackStage& stage = combat.currentStage();
+			// Consume stamina for this swing stage (read BEFORE advanceChain)
+			if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+				stamina->consume(stage.staminaCost);
+			hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
+			combat.advanceChain();
+			fprintf(stderr, "[COMBAT] deferred_hit applied  next_chain_stage=%d\n", combat.chainStage);
+		}
+		combat.hitPending = false;
+	}
+```
+
+- [ ] **Step 8: Consume stamina in `tickSkillSlot`**
+
+In `tickSkillSlot()`, add stamina consumption after the cast finishes. At line 453 (inside `if (hitPending)`, before `SkillContext ctx`), add:
+
+```cpp
+		// Consume stamina when cast completes
+		if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+			stamina->consume(def.staminaCost);
+```
+
+The full modified block (lines 453-459) should read:
+
+```cpp
+	if (hitPending) {
+		// Consume stamina when cast completes
+		if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+			stamina->consume(def.staminaCost);
+		if (health.isAlive()) {
+			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
+			executeSkill(def, ctx);
+		}
+		hitPending = false;
+	}
+```
+
+- [ ] **Step 9: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add game-core/src/systems/CombatSystem.hpp
+git commit -m "feat(game): integrate stamina gating into CombatSystem"
+```
+
+---
+
+### Task 8: Integrate stamina into `CharacterControllerSystem`
+
+**Files:**
+- Modify: `game-core/src/systems/CharacterControllerSystem.hpp:1-8` (includes), `45-58` (earlyUpdate), `60-126` (processCharacterMovement)
+
+- [ ] **Step 1: Add includes**
+
+In `game-core/src/systems/CharacterControllerSystem.hpp`, add after line 6 (`#include "../components/CharacterController.hpp"`):
+
+```cpp
+#include "../components/Stamina.hpp"
+```
+
+- [ ] **Step 2: Update `earlyUpdate` to get Stamina component**
+
+Replace the view and lambda in `earlyUpdate()` (lines 47-57) with:
+
+```cpp
+	auto view = m_registry->view<
+		Components::CharacterController,
+		Components::PhysicsBody,
+		Components::Transform,
+		Components::Stamina
+	>();
+
+	view.each([&](Components::CharacterController& controller,
+		Components::PhysicsBody& physics,
+		Components::Transform& transform,
+		Components::Stamina& stamina) {
+		processCharacterMovement(controller, physics, transform, stamina, deltaTime);
+		});
+```
+
+- [ ] **Step 3: Update `processCharacterMovement` signature**
+
+Update the declaration at lines 33-38:
+
+```cpp
+	void processCharacterMovement(
+		Components::CharacterController& controller,
+		Components::PhysicsBody& physics,
+		Components::Transform& transform,
+		Components::Stamina& stamina,
+		float deltaTime
+	);
+```
+
+Update the definition at lines 60-65:
+
+```cpp
+inline void CharacterControllerSystem::processCharacterMovement(
+	Components::CharacterController& controller,
+	Components::PhysicsBody& physics,
+	Components::Transform& transform,
+	Components::Stamina& stamina,
+	float deltaTime
+) {
+```
+
+- [ ] **Step 4: Add sprint stamina drain**
+
+Replace line 72 (`controller.isSprinting = controller.input.isSprinting;`) with:
+
+```cpp
+	// Sprint gating: require stamina and not exhausted
+	if (controller.input.isSprinting) {
+		float frameCost = stamina.sprintCostPerSec * deltaTime;
+		if (!stamina.isExhausted() && stamina.canAfford(frameCost)) {
+			stamina.consume(frameCost);
+			controller.isSprinting = true;
+		} else {
+			controller.isSprinting = false;
+		}
+	} else {
+		controller.isSprinting = false;
+	}
+```
+
+- [ ] **Step 5: Add jump stamina check**
+
+Replace lines 107-108:
+
+```cpp
+	if (controller.input.isJumping && controller.canJump && physics.isGrounded) {
+		physics.velocity.y = controller.jumpVelocity;
+```
+
+With:
+
+```cpp
+	if (controller.input.isJumping && controller.canJump && physics.isGrounded
+			&& stamina.canAfford(stamina.jumpCost)) {
+		stamina.consume(stamina.jumpCost);
+		physics.velocity.y = controller.jumpVelocity;
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `make build`
+Expected: Compiles cleanly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add game-core/src/systems/CharacterControllerSystem.hpp
+git commit -m "feat(game): integrate stamina into sprint and jump gating"
+```
+
+---
+
+### Task 9: Add stamina to the snapshot pipeline (C++ side)
+
+**Files:**
+- Modify: `game-core/src/ArenaGame.hpp:14-30` (CharacterSnapshot struct), `191-239` (createSnapshot)
+- Modify: `game-core/src/cxx_bridge.cpp:107-122` (bridge mapping)
+
+- [ ] **Step 1: Add include for Stamina component**
+
+In `game-core/src/ArenaGame.hpp`, add after line 3 (`#include "core/World.hpp"`):
+
+```cpp
+#include "components/Stamina.hpp"
+```
+
+- [ ] **Step 2: Add fields to C++ `CharacterSnapshot`**
+
+In `game-core/src/ArenaGame.hpp`, add after line 27 (`float swingProgress;`):
+
+```cpp
+	// Stamina data for HUD
+	float stamina;
+	float maxStamina;
+```
+
+- [ ] **Step 3: Add Stamina to `createSnapshot` view**
+
+Update the view template at lines 200-207 to include `Components::Stamina`:
+
+```cpp
+	auto view = registry.view<
+		Components::PlayerInfo,
+		Components::Transform,
+		Components::PhysicsBody,
+		Components::Health,
+		Components::CharacterController,
+		Components::CombatController,
+		Components::Stamina
+	>();
+```
+
+Update the lambda at lines 210-215 to include `Components::Stamina& stam`:
+
+```cpp
+	view.each([&](Components::PlayerInfo& playerInfo,
+				  Components::Transform& transform,
+				  Components::PhysicsBody& physics,
+				  Components::Health& health,
+				  Components::CharacterController& controller,
+				  Components::CombatController& combat,
+				  Components::Stamina& stam) {
+```
+
+- [ ] **Step 4: Populate stamina snapshot fields**
+
+Add after line 233 (`charSnapshot.swingProgress = ...`):
+
+```cpp
+		charSnapshot.stamina    = stam.current;
+		charSnapshot.maxStamina = stam.maximum;
+```
+
+- [ ] **Step 5: Add stamina to CXX bridge mapping**
+
+In `game-core/src/cxx_bridge.cpp`, update the `CharacterSnapshot` construction in `get_snapshot()` (lines 108-121). Add after `/* swing_progress    */` (line 120):
+
+```cpp
+            /* stamina           */ c.stamina,
+            /* max_stamina       */ c.maxStamina,
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `make build`
+Expected: Build fails — Rust CXX bridge struct doesn't have the new fields yet. This is expected and fixed in Task 10.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add game-core/src/ArenaGame.hpp game-core/src/cxx_bridge.cpp
+git commit -m "feat(game): add stamina fields to C++ snapshot and CXX bridge"
+```
+
+---
+
+### Task 10: Add stamina to the Rust FFI bridge
+
+**Files:**
+- Modify: `backend/src/game/ffi.rs:43-56` (bridge CharacterSnapshot), `198-212` (Rust CharacterSnapshot), `214-238` (From impl)
+
+- [ ] **Step 1: Add fields to CXX bridge struct**
+
+In `backend/src/game/ffi.rs`, add after line 55 (`swing_progress: f32,`):
+
+```rust
+        stamina: f32,
+        max_stamina: f32,
+```
+
+- [ ] **Step 2: Add fields to Rust CharacterSnapshot**
+
+In the same file, add after line 211 (`pub swing_progress: f32,`):
+
+```rust
+    pub stamina: f32,
+    pub max_stamina: f32,
+```
+
+- [ ] **Step 3: Add fields to From impl**
+
+In the `From<bridge::CharacterSnapshot>` impl, add after line 236 (`swing_progress: c.swing_progress,`):
+
+```rust
+            stamina: c.stamina,
+            max_stamina: c.max_stamina,
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `cargo build` (from `backend/` directory)
+Expected: Compiles cleanly. Full pipeline is wired: C++ → CXX bridge → Rust.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/game/ffi.rs
+git commit -m "feat(backend): add stamina fields to Rust FFI bridge"
+```
+
+---
+
+### Task 11: Add stamina to frontend types
+
+**Files:**
+- Modify: `frontend/src/game/types.ts:10-24`
+
+- [ ] **Step 1: Add fields to TypeScript `CharacterSnapshot`**
+
+In `frontend/src/game/types.ts`, add after line 23 (`swing_progress: number;`):
+
+```typescript
+	// Stamina data
+	stamina: number;
+	max_stamina: number;
+```
+
+- [ ] **Step 2: Verify frontend build**
+
+Run: `npm run build` (from `frontend/` directory)
+Expected: Compiles cleanly. The frontend now receives stamina data in every snapshot.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/game/types.ts
+git commit -m "feat(frontend): add stamina fields to CharacterSnapshot type"
+```
+
+---
+
+### Task 12: Full integration build and smoke test
+
+- [ ] **Step 1: Full build**
+
+Run the full project build to verify all C++/Rust/TypeScript compile together:
+
+```bash
+make build
+```
+
+Expected: Clean build with no errors or warnings related to stamina.
+
+- [ ] **Step 2: Verify snapshot pipeline**
+
+Start the game server and connect a client. Verify that `CharacterSnapshot` objects arriving at the frontend contain `stamina` and `max_stamina` fields with expected values (100.0 for Knight at spawn).
+
+- [ ] **Step 3: Manual smoke test**
+
+Test each stamina behavior in-game:
+1. **Sprint drain:** Hold sprint — character should slow to walk after ~6.6s
+2. **Attack gating:** Spam attacks — after two full combos, attacks should stop
+3. **Skill gating:** Use ability2 (cost 30) then ability1 (cost 20) — should work. Use both abilities + a combo — should hit stamina limit
+4. **Jump cost:** Spam jump — should stop after ~12 jumps
+5. **Regen:** After draining to 50%, stop all actions — should recover in ~1.7s
+6. **Exhaustion:** Drain to 0% — should see 1.5s delay, then slow regen starting at floor rate
+7. **Respawn:** Die and respawn — stamina should be full
+
+- [ ] **Step 4: Final commit**
+
+If any tweaks were needed during smoke testing, commit them:
+
+```bash
+git add -A
+git commit -m "fix(game): stamina system tuning from smoke test"
+```

--- a/docs/superpowers/specs/2026-04-10-stamina-system-design.md
+++ b/docs/superpowers/specs/2026-04-10-stamina-system-design.md
@@ -230,7 +230,8 @@ when player wants to attack and comcon.canPerformAttack():
 
 **When swing completes (`handleSwingEnd`):**
 ```
-    cost = comcon.attackChain[completedStage].staminaCost
+    // Read cost BEFORE advanceChain(), since advanceChain() increments chainStage
+    cost = comcon.attackChain[comcon.chainStage].staminaCost
     stamina.consume(cost)
     // Then proceed with advanceChain(), hit resolution, etc. as normal
 ```
@@ -258,8 +259,10 @@ when player wants to use ability2 and comcon.canUseAbility2():
 ```
 
 **When cast completes (`tickSkillSlot`):**
+
+`tickSkillSlot` ticks every frame during the cast. Stamina is consumed only once, at the moment the cast timer expires (i.e. `castTimer <= 0`), not every frame:
 ```
-    // tickSkillSlot already knows which slot it's processing
+    // Inside tickSkillSlot, in the branch where castTimer just expired this frame:
     cost = skillDefinition.staminaCost   // ability1 or ability2 respectively
     stamina.consume(cost)
     // Then proceed with executeSkill(), cooldown start, etc. as normal
@@ -268,6 +271,33 @@ when player wants to use ability2 and comcon.canUseAbility2():
 #### Buffered Actions
 
 If a player buffers an attack or skill while already mid-action, the stamina check happens when the buffer is consumed (i.e. when the current action ends and the buffered action would start), **not** when the input is buffered. This prevents the edge case where stamina changes between buffering and execution.
+
+**Buffer consumption path:**
+```
+when current action ends and comcon.bufferedAction != None:
+    if bufferedAction == Attack:
+        cost = comcon.attackChain[comcon.chainStage].staminaCost
+        if !stamina.canAfford(cost):
+            comcon.bufferedAction = None   // discard — can no longer afford it
+            return
+        // Proceed with startAttack() as normal
+
+    if bufferedAction == Skill1:
+        cost = comcon.ability1.staminaCost
+        if !stamina.canAfford(cost):
+            comcon.bufferedAction = None
+            return
+        // Proceed with triggerSkill() for slot 1
+
+    if bufferedAction == Skill2:
+        cost = comcon.ability2.staminaCost
+        if !stamina.canAfford(cost):
+            comcon.bufferedAction = None
+            return
+        // Proceed with triggerSkill() for slot 2
+```
+
+If the player can no longer afford the buffered action when it would fire, the buffer is silently discarded. The buffer does not persist waiting for stamina — it is a one-shot that either fires or is dropped.
 
 ### CharacterControllerSystem Modifications
 
@@ -288,7 +318,9 @@ if input.isSprinting:
 
 Sprint is the only action with a **continuous** stamina cost (per-second). All other actions have discrete, one-time costs.
 
-Sprint uses `canAfford(frameCost)` for consistency with all other stamina checks (not a raw `current > 0` comparison). It also checks `isExhausted()` explicitly — this prevents a stutter loop where a player exits exhaustion with a tiny amount of stamina, sprints for one frame, drains to zero, re-enters exhaustion, waits 1.5s, and repeats. By blocking sprint during exhaustion, the player must wait for meaningful stamina to accumulate before sprinting again.
+Sprint uses `canAfford(frameCost)` as the **primary gate** — this is what actually prevents sprinting with insufficient stamina. The `isExhausted()` check is a **secondary guard** specifically for stutter-loop prevention: without it, a player could exit exhaustion with a tiny amount of stamina, sprint for one frame, drain to zero, re-enter exhaustion, wait 1.5s, and repeat. By blocking sprint during exhaustion, the player must wait for meaningful stamina to accumulate before sprinting again.
+
+**Frame ordering note:** `CharacterControllerSystem` runs in `earlyUpdate`. If an attack in `CombatSystem` (which runs later in `update`) drains stamina to zero, `exhausted` is not yet set (that happens in `StaminaSystem` during `lateUpdate`). On the next frame, sprint's `isExhausted()` would return false — but `canAfford(frameCost)` returns false (since `current == 0` and `frameCost > 0`), so sprint is still correctly blocked. The `canAfford` check is the operative guard; `isExhausted` provides the stutter-loop protection once the flag is set.
 
 Sprint is forcibly disabled when stamina is insufficient or exhausted. The player's input still says `isSprinting = true`, but the server overrides it. The client will see the speed change via the snapshot.
 
@@ -298,16 +330,16 @@ In `processCharacterMovement()`, when processing jump input:
 
 ```
 if input.isJumping and controller.canJump:
-    if !stamina.canAfford(jumpCost):
+    if !stamina.canAfford(stamina.jumpCost):
         // Reject jump — do nothing
     else:
-        stamina.consume(jumpCost)
+        stamina.consume(stamina.jumpCost)
         // Proceed with jump as normal
 ```
 
-Jump cost is consumed **immediately** (unlike attacks/skills which defer to completion). There is no "jump duration" — the player either jumps or doesn't.
+Jump cost is consumed **immediately** (unlike attacks/skills which defer to completion). There is no "jump duration" — the player either jumps or doesn't. `jumpCost` is read from the `Stamina` component (populated from `StaminaPreset.jumpCost` at spawn).
 
-`jumpCost` is read from `StaminaPreset.jumpCost`, stored on the entity at spawn time. This value comes from the character preset so different classes can have different jump costs.
+**Regen while airborne:** Jumping does not suppress stamina regen. The jump cost is a one-time deduction; once airborne, the player is not actively "consuming" stamina, so regen proceeds normally (subject to the other suppression checks). This is intentional — jumping is a discrete cost, not a continuous drain like sprinting.
 
 ---
 
@@ -315,10 +347,14 @@ Jump cost is consumed **immediately** (unlike attacks/skills which defer to comp
 
 ### Snapshot Changes
 
-Stamina data flows through four layers to reach the client. All four must be updated:
+Stamina data flows through five layers to reach the client. All five must be updated:
 
 **1. C++ `CharacterSnapshot` struct (`ArenaGame.hpp`):**
-Add `stamina` and `max_stamina` fields to the `CharacterSnapshot` struct definition (alongside existing `health` and `max_health`).
+Add fields to the `CharacterSnapshot` struct using C++ camelCase convention (matching existing `maxHealth`):
+```cpp
+float stamina;      // current stamina
+float maxStamina;   // maximum stamina pool
+```
 
 **2. C++ `ArenaGame::createSnapshot()` (`ArenaGame.hpp`):**
 The `createSnapshot()` method must include `Stamina` in the entity view template and populate the new snapshot fields from `stamina.current` and `stamina.maximum`.

--- a/docs/superpowers/specs/2026-04-10-stamina-system-design.md
+++ b/docs/superpowers/specs/2026-04-10-stamina-system-design.md
@@ -1,0 +1,407 @@
+# Stamina System Design
+
+## Overview
+
+A server-authoritative stamina resource system that prevents infinite sprinting and attack spamming. Stamina gates all physical actions (sprinting, attacking, using skills, jumping) and regenerates at a rate proportional to current stamina percentage, rewarding conservation and punishing reckless resource spending.
+
+## Goals
+
+- **Prevent spam:** Players cannot endlessly chain attacks or sprint without consequence.
+- **Create tactical rhythm:** The regen curve (more stamina = faster regen) rewards players who manage their resources and punishes those who drain to zero.
+- **Class identity:** Per-class stamina costs and pools let character presets feel mechanically distinct (e.g. Knight's heavy swings cost more than a Rogue's quick strikes).
+- **Consistent architecture:** Follow existing ECS patterns — the `Stamina` component mirrors `Health`, the `StaminaSystem` mirrors existing system conventions.
+
+## Architecture
+
+### Approach: Standalone Component + System
+
+Stamina is implemented as a new ECS component (`Stamina`) with a dedicated system (`StaminaSystem`) owning regen logic. Existing systems (`CombatSystem`, `CharacterControllerSystem`) query the `Stamina` component for affordability checks and consume stamina at the appropriate moments.
+
+This was chosen over embedding stamina into `CombatController` (split ownership between combat and movement) or extending `Health` (conflates two independent resources with different regen rules).
+
+---
+
+## Component Design
+
+### StaminaPreset (pure data, lives in CharacterPreset)
+
+Added to `CharacterPreset.hpp` alongside `HealthPreset`, `MovementPreset`, etc.
+
+```cpp
+struct StaminaPreset {
+    float maxStamina;          // total stamina pool
+    float baseRegenRate;       // maximum regen per second (achieved at 100% stamina)
+    float drainDelaySeconds;   // seconds of no regen after stamina is fully depleted
+    float sprintCostPerSec;    // stamina consumed per second while sprinting
+    float jumpCost;            // flat stamina consumed per jump
+};
+```
+
+Added to the root `CharacterPreset` struct:
+```cpp
+struct CharacterPreset {
+    HealthPreset health;
+    MovementPreset movement;
+    ColliderPreset collider;
+    CombatPreset combat;
+    StaminaPreset stamina;     // NEW
+};
+```
+
+### Stamina Component (ECS runtime data)
+
+New file: `game-core/src/components/Stamina.hpp`
+
+Mirrors the `Health` component pattern: plain data struct with convenience methods, no logic beyond simple state queries and mutations.
+
+**Fields:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `current` | `float` | Current stamina value. Clamped to `[0, maximum]`. |
+| `maximum` | `float` | Maximum stamina pool. Set from `StaminaPreset.maxStamina`. |
+| `baseRegenRate` | `float` | Max regen per second (at 100% stamina). Set from `StaminaPreset.baseRegenRate`. |
+| `drainDelay` | `float` | Configured pause duration (seconds) after full depletion. Set from `StaminaPreset.drainDelaySeconds`. |
+| `drainDelayTimer` | `float` | Runtime countdown. Set to `drainDelay` when stamina hits zero, counts down each frame. Regen blocked while `> 0`. |
+| `exhausted` | `bool` | `true` from the moment stamina hits zero until `drainDelayTimer` expires. Used by other systems to query exhaustion state. |
+| `sprintCostPerSec` | `float` | Stamina consumed per second while sprinting. Set from `StaminaPreset.sprintCostPerSec`. Stored here so `CharacterControllerSystem` can read it without accessing the preset. |
+| `jumpCost` | `float` | Flat stamina consumed per jump. Set from `StaminaPreset.jumpCost`. Stored here for the same reason. |
+
+**Methods:**
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `consume` | `void consume(float amount)` | Subtracts `amount` from `current`. Clamps to `0`. Does **not** set `exhausted` — that is `StaminaSystem`'s responsibility. |
+| `canAfford` | `bool canAfford(float cost) const` | Returns `current >= cost`. Used by `CombatSystem` and `CharacterControllerSystem` to gate actions. |
+| `recover` | `void recover(float amount)` | Adds `amount` to `current`. Clamps to `maximum`. |
+| `restore` | `void restore()` | Sets `current = maximum`, `exhausted = false`, `drainDelayTimer = 0`. Used on spawn/respawn. |
+| `getPercent` | `float getPercent() const` | Returns `current / maximum`. Range `[0.0, 1.0]`. |
+| `isExhausted` | `bool isExhausted() const` | Returns `exhausted`. |
+| `isFull` | `bool isFull() const` | Returns `current >= maximum`. |
+| `createFromPreset` | `static Stamina createFromPreset(const StaminaPreset& preset)` | Factory. Sets `current = maximum = preset.maxStamina`, `baseRegenRate = preset.baseRegenRate`, `drainDelay = preset.drainDelaySeconds`, `sprintCostPerSec = preset.sprintCostPerSec`, `jumpCost = preset.jumpCost`, `exhausted = false`, `drainDelayTimer = 0`. |
+
+### Stamina Costs on Actions
+
+**AttackStage** — add a `staminaCost` field:
+```cpp
+struct AttackStage {
+    float damageMultiplier;
+    float range;
+    float duration;
+    float movementMultiplier;
+    float chainWindow;
+    float attackAngle = 1.047f;
+    float staminaCost = 0.0f;   // NEW: stamina consumed when this stage completes
+};
+```
+
+**SkillDefinition** — add a `staminaCost` field:
+```cpp
+struct SkillDefinition {
+    SkillVariant params;
+    float cooldown;
+    float castDuration;
+    float staminaCost = 0.0f;   // NEW: stamina consumed when cast completes
+};
+```
+
+Default of `0.0f` ensures backward compatibility — any attack or skill without an explicit cost is free.
+
+---
+
+## StaminaSystem (new ECS system)
+
+New file: `game-core/src/systems/StaminaSystem.hpp`
+
+### Responsibilities
+
+Sole owner of stamina regeneration logic. Does **not** consume stamina — that is done by `CombatSystem` (attacks/skills) and `CharacterControllerSystem` (sprint/jump). `StaminaSystem` only handles:
+
+1. Detecting full depletion and entering exhaustion state.
+2. Ticking the drain delay timer during exhaustion.
+3. Clearing exhaustion when the delay expires.
+4. Applying scaled regen when the player is not consuming stamina.
+
+### Update Phase
+
+Runs in `FixedUpdate`, **after** `CombatSystem` and `CharacterControllerSystem`. This ordering ensures that stamina consumption for the current tick is already applied before regen ticks, preventing regen from "undoing" a spend in the same frame.
+
+### Per-Entity Logic (every tick)
+
+```
+for each entity with (Stamina, CharacterController, CombatController, Health):
+
+    // 1. Dead players don't regen
+    if !health.isAlive():
+        continue
+
+    // 2. Detect full depletion → enter exhaustion
+    if stamina.current <= 0 and !stamina.exhausted:
+        stamina.exhausted = true
+        stamina.drainDelayTimer = stamina.drainDelay
+
+    // 3. Tick drain delay during exhaustion
+    if stamina.exhausted:
+        stamina.drainDelayTimer -= deltaTime
+        if stamina.drainDelayTimer <= 0:
+            stamina.exhausted = false
+        else:
+            continue   // no regen during drain delay
+
+    // 4. No regen while actively spending stamina
+    if controller.isSprinting:  continue
+    if combat.isAttacking:      continue
+    if combat.isCasting():      continue
+
+    // 5. Scaled regen with 10% minimum floor
+    effectiveRate = stamina.baseRegenRate * (stamina.current / stamina.maximum)
+    effectiveRate = max(effectiveRate, stamina.baseRegenRate * 0.10)
+
+    stamina.current = min(stamina.current + effectiveRate * deltaTime, stamina.maximum)
+```
+
+### Regen Formula Details
+
+**Core formula:** `effectiveRate = baseRegenRate * (current / maximum)`
+
+This creates a smooth curve where regen is proportional to how full the bar is:
+- At 100% stamina: regen = 100% of baseRegenRate (not needed, bar is full)
+- At 80% stamina: regen = 80% of baseRegenRate (fast recovery)
+- At 50% stamina: regen = 50% of baseRegenRate (moderate)
+- At 20% stamina: regen = 20% of baseRegenRate (slow)
+- At 5% stamina: regen = 10% of baseRegenRate (minimum floor kicks in)
+
+**Minimum floor: 10% of baseRegenRate.** Without this floor, recovering from near-zero would be agonizingly slow (1% stamina = 1% regen rate). The 10% floor ensures recovery from low stamina is sluggish but not frustrating. Players still feel the penalty of draining low, but aren't stuck doing nothing.
+
+**Full depletion penalty:** When stamina hits exactly zero, the `exhausted` flag is set and `drainDelayTimer` starts counting down from `drainDelay`. During this window, **no regen occurs at all** — the player is locked out. Once the timer expires, `exhausted` clears and normal scaled regen begins (starting at the 10% floor since current is near zero).
+
+---
+
+## Combat Integration
+
+### CombatSystem Modifications
+
+All changes are in `CombatSystem.hpp`. The system gains access to the `Stamina` component through the existing entity registry.
+
+#### Attack Gating (`processInputAttacks`)
+
+**Before starting an attack:**
+```
+when player wants to attack and comcon.canPerformAttack():
+    cost = comcon.attackChain[comcon.chainStage].staminaCost
+    if !stamina.canAfford(cost):
+        // Silently reject — player cannot attack
+        // Do NOT buffer the attack input
+        return
+    // Proceed with comcon.startAttack() as normal
+```
+
+**When swing completes (`handleSwingEnd`):**
+```
+    cost = comcon.attackChain[completedStage].staminaCost
+    stamina.consume(cost)
+    // Then proceed with advanceChain(), hit resolution, etc. as normal
+```
+
+**Design decision: check before, consume after.** The player must have enough stamina to *initiate* the attack, but the cost is deducted when the swing completes. This means a player who starts an attack with exactly enough stamina will hit zero after the swing and enter exhaustion — a fair trade for committing to the action. It also prevents exploits where stamina is consumed but the attack is cancelled mid-swing.
+
+#### Skill Gating (`triggerSkill`)
+
+Same pattern as attacks:
+
+**Before starting a skill:**
+```
+when player wants to use ability and comcon.canUseAbility():
+    cost = skillDefinition.staminaCost
+    if !stamina.canAfford(cost):
+        // Silently reject — player cannot use this skill
+        return
+    // Proceed with triggerSkill() as normal
+```
+
+**When cast completes (`tickSkillSlot`):**
+```
+    cost = skillDefinition.staminaCost
+    stamina.consume(cost)
+    // Then proceed with executeSkill(), cooldown start, etc. as normal
+```
+
+#### Buffered Actions
+
+If a player buffers an attack or skill while already mid-action, the stamina check happens when the buffer is consumed (i.e. when the current action ends and the buffered action would start), **not** when the input is buffered. This prevents the edge case where stamina changes between buffering and execution.
+
+### CharacterControllerSystem Modifications
+
+#### Sprint Drain
+
+In `processCharacterMovement()`, after determining the player wants to sprint:
+
+```
+if input.isSprinting:
+    if stamina.current > 0:
+        stamina.consume(sprintCostPerSec * deltaTime)
+        // Sprint proceeds normally — apply sprintMultiplier to speed
+    else:
+        controller.isSprinting = false
+        // Fall back to walk speed — override player input
+```
+
+Sprint is the only action with a **continuous** stamina cost (per-second). All other actions have discrete, one-time costs.
+
+Sprint is forcibly disabled when stamina reaches zero. The player's input still says `isSprinting = true`, but the server overrides it. The client will see the speed change via the snapshot.
+
+#### Jump Cost
+
+In `processCharacterMovement()`, when processing jump input:
+
+```
+if input.isJumping and controller.canJump:
+    if !stamina.canAfford(jumpCost):
+        // Reject jump — do nothing
+    else:
+        stamina.consume(jumpCost)
+        // Proceed with jump as normal
+```
+
+Jump cost is consumed **immediately** (unlike attacks/skills which defer to completion). There is no "jump duration" — the player either jumps or doesn't.
+
+`jumpCost` is read from `StaminaPreset.jumpCost`, stored on the entity at spawn time. This value comes from the character preset so different classes can have different jump costs.
+
+---
+
+## Network & Snapshot Integration
+
+### Snapshot Changes
+
+**C++ side:** The snapshot generation code adds two floats to the per-player data passed through the CXX bridge:
+- `stamina` — current stamina value (`stamina.current`)
+- `max_stamina` — maximum stamina value (`stamina.maximum`)
+
+**Rust FFI (`ffi.rs`):** Add fields to `CharacterSnapshot`:
+```rust
+pub struct CharacterSnapshot {
+    // ... existing fields ...
+    pub stamina: f32,
+    pub max_stamina: f32,
+}
+```
+
+**Rust messages (`messages.rs`):** No new message type. Stamina state rides the existing `Snapshot(GameStateSnapshot)` message sent every tick at 60 Hz. Two extra floats per player is negligible bandwidth overhead (~8 bytes per player per tick).
+
+**Frontend types (`types.ts`):** Add matching fields to `CharacterSnapshot`:
+```typescript
+export interface CharacterSnapshot {
+    // ... existing fields ...
+    stamina: number;
+    max_stamina: number;
+}
+```
+
+### No Discrete Stamina Events
+
+Unlike `Damage` or `Death`, there is no `StaminaChanged` event message. The snapshot provides stamina every frame, making a discrete event redundant. The client can derive all display states (low stamina warning, exhaustion indicator) from the snapshot values.
+
+### Frontend Display
+
+This spec intentionally **does not define** stamina bar UI visuals (bar style, position, color, exhaustion effects). The snapshot delivers `stamina` and `max_stamina` to the client every frame — all data needed for any UI treatment. Visual design is a separate concern to be addressed independently.
+
+---
+
+## Entity Lifecycle
+
+### Spawn (new player joins or respawns after death)
+
+When a player entity is created:
+1. `Stamina` component is attached via `Stamina::createFromPreset(characterPreset.stamina)`
+2. Stamina starts at `maximum` (full bar)
+3. `exhausted = false`, `drainDelayTimer = 0`
+
+This happens in the same entity construction code that attaches `Health`, `CharacterController`, `CombatController`, etc.
+
+### Death
+
+When a player dies:
+- Stamina **stops regenerating** — the `health.isAlive()` guard in `StaminaSystem` handles this automatically.
+- Stamina values are not explicitly zeroed — they become irrelevant while the player is dead.
+- No special handling needed.
+
+### Respawn
+
+When a player revives:
+- Call `stamina.restore()` — sets `current = maximum`, clears `exhausted` and `drainDelayTimer`.
+- This is added alongside the existing `Health::revive()` call in the respawn logic.
+- Player starts the new life with full stamina, clean state.
+
+### Game Mode Reset (e.g. round restart)
+
+Same as respawn — `stamina.restore()` is called during the reset sequence that already restores health and repositions players.
+
+---
+
+## Knight Preset Values
+
+Starting tuning values for the Knight class. These are balance numbers intended to be adjusted through playtesting.
+
+### StaminaPreset
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `maxStamina` | `100.0` | Round number, easy to reason about costs as percentages |
+| `baseRegenRate` | `20.0/s` | At full stamina: 5s from empty to full. Effective range: 2.0/s (10% floor) to 20.0/s (100%) |
+| `drainDelaySeconds` | `1.5s` | Punishing but not rage-inducing. Long enough to feel the mistake of full drain |
+| `sprintCostPerSec` | `15.0/s` | ~6.6 seconds of continuous sprint from full. Enough to cross the arena but not endlessly kite |
+| `jumpCost` | `8.0` | ~12 jumps from full. Bunny-hopping burns resources fast |
+
+### Attack Chain Costs
+| Stage | Cost | Rationale |
+|-------|------|-----------|
+| Stage 1 (light slash) | `10.0` | Cheap opener, low commitment |
+| Stage 2 (follow-up) | `15.0` | Moderate investment to continue |
+| Stage 3 (heavy finisher) | `25.0` | Expensive payoff — rewards landing the full chain |
+
+Full 3-hit combo = **50 stamina** (half the pool). Two full combos back-to-back depletes the bar entirely.
+
+### Skill Costs
+| Skill | Cost | Rationale |
+|-------|------|-----------|
+| Ability 1 | `20.0` | Moderate cost, can still combo after |
+| Ability 2 | `30.0` | Heavy commitment, limits follow-up options |
+
+### Recovery Scenarios
+| Scenario | Timeline |
+|----------|----------|
+| Full drain (0%) | 1.5s delay → starts at 10% floor (2.0/s) → ~50% in ~6s → ~100% in ~10s total |
+| Drain to 50% (no depletion) | Immediate regen at 10.0/s → back to full in ~3s |
+| Drain to 25% | Immediate regen at 5.0/s → back to full in ~5s |
+| One combo (50% remaining) | Immediate regen at 10.0/s → full in ~3s |
+
+The takeaway: **conservative play recovers in seconds, reckless play costs 10+ seconds**. This is the core incentive loop.
+
+### Future Classes (not yet in codebase)
+
+When Rogue and Mage presets are added, the stamina system supports them with no code changes — only new preset values:
+- **Rogue:** Lower `maxStamina` (~80), lower per-attack costs (~5-15), faster `baseRegenRate` (~25/s). Cheap quick attacks, smaller pool.
+- **Mage:** Higher `maxStamina` (~120), higher skill costs (~30-40), lower `baseRegenRate` (~15/s). Spell-heavy, pool management matters more.
+
+These are hypothetical examples — actual values would be tuned when the classes are implemented.
+
+---
+
+## Files Changed Summary
+
+### New Files
+| File | Description |
+|------|-------------|
+| `game-core/src/components/Stamina.hpp` | Stamina ECS component (data + convenience methods) |
+| `game-core/src/systems/StaminaSystem.hpp` | Stamina regen system (owns all regen logic) |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `game-core/src/CharacterPreset.hpp` | Add `StaminaPreset` struct, add `stamina` field to `CharacterPreset` |
+| `game-core/src/Presets.hpp` | Populate `StaminaPreset` values for Knight |
+| `game-core/src/Skills.hpp` | Add `staminaCost` field to `AttackStage` and `SkillDefinition` |
+| `game-core/src/systems/CombatSystem.hpp` | Stamina checks before attacks/skills, consume on completion |
+| `game-core/src/systems/CharacterControllerSystem.hpp` | Sprint drain per frame, jump cost, sprint disable on empty |
+| `game-core/src/systems/SystemManager.hpp` | Register `StaminaSystem` in update loop |
+| `game-core/src/ArenaGame.hpp` | Attach `Stamina` component on entity creation, `restore()` on respawn |
+| `backend/src/game/ffi.rs` | Add `stamina`, `max_stamina` to `CharacterSnapshot` |
+| `backend/src/game/messages.rs` | Add `stamina`, `max_stamina` to snapshot serialization (if separate from ffi) |
+| `frontend/src/game/types.ts` | Add `stamina`, `max_stamina` to `CharacterSnapshot` interface |

--- a/docs/superpowers/specs/2026-04-10-stamina-system-design.md
+++ b/docs/superpowers/specs/2026-04-10-stamina-system-design.md
@@ -105,6 +105,8 @@ struct SkillDefinition {
 
 Default of `0.0f` ensures backward compatibility — any attack or skill without an explicit cost is free.
 
+**Zero-cost actions during exhaustion:** A `staminaCost` of `0.0f` means `canAfford(0)` returns `true` even when stamina is zero or the player is exhausted. This is intentional — zero-cost actions are explicitly free and usable at all times. All Knight attacks and skills have non-zero costs, so this only affects future content where a designer deliberately sets cost to zero (e.g. a passive ability or a basic action that shouldn't be gated). If a future design requires exhaustion to block all actions regardless of cost, add an `isExhausted()` check to the gating logic — but that is not part of this spec.
+
 ---
 
 ## StaminaSystem (new ECS system)
@@ -120,9 +122,24 @@ Sole owner of stamina regeneration logic. Does **not** consume stamina — that 
 3. Clearing exhaustion when the delay expires.
 4. Applying scaled regen when the player is not consuming stamina.
 
+### Required Component Access
+
+`StaminaSystem` requires read access to the following components on each entity:
+- `CharacterController` — reads `isSprinting` to suppress regen during sprint.
+- `CombatController` — reads `isAttacking`, `isAbility1Casting()`, `isAbility2Casting()` to suppress regen during combat actions.
+- `Health` — reads `isAlive()` to skip dead players.
+
 ### Update Phase
 
-Runs in `FixedUpdate`, **after** `CombatSystem` and `CharacterControllerSystem`. This ordering ensures that stamina consumption for the current tick is already applied before regen ticks, preventing regen from "undoing" a spend in the same frame.
+Runs in `lateUpdate()`. The existing system execution order is:
+
+```
+earlyUpdate  →  fixedUpdate  →  update     →  lateUpdate
+     ↑                             ↑              ↑
+CharControllerSystem          CombatSystem    StaminaSystem
+```
+
+`CharacterControllerSystem` runs in `earlyUpdate` (consumes sprint stamina), `CombatSystem` runs in `update` (consumes attack/skill stamina). By placing `StaminaSystem` in `lateUpdate`, it runs **after both**, ensuring all stamina consumption for the current tick is applied before regen ticks. This prevents regen from "undoing" a spend in the same frame.
 
 ### Per-Entity Logic (every tick)
 
@@ -147,9 +164,10 @@ for each entity with (Stamina, CharacterController, CombatController, Health):
             continue   // no regen during drain delay
 
     // 4. No regen while actively spending stamina
-    if controller.isSprinting:  continue
-    if combat.isAttacking:      continue
-    if combat.isCasting():      continue
+    if controller.isSprinting:          continue
+    if combat.isAttacking:              continue
+    if combat.isAbility1Casting():      continue
+    if combat.isAbility2Casting():      continue
 
     // 5. Scaled regen with 10% minimum floor
     effectiveRate = stamina.baseRegenRate * (stamina.current / stamina.maximum)
@@ -172,6 +190,22 @@ This creates a smooth curve where regen is proportional to how full the bar is:
 **Minimum floor: 10% of baseRegenRate.** Without this floor, recovering from near-zero would be agonizingly slow (1% stamina = 1% regen rate). The 10% floor ensures recovery from low stamina is sluggish but not frustrating. Players still feel the penalty of draining low, but aren't stuck doing nothing.
 
 **Full depletion penalty:** When stamina hits exactly zero, the `exhausted` flag is set and `drainDelayTimer` starts counting down from `drainDelay`. During this window, **no regen occurs at all** — the player is locked out. Once the timer expires, `exhausted` clears and normal scaled regen begins (starting at the 10% floor since current is near zero).
+
+### Recovery Math
+
+The regen formula creates a piecewise ODE due to the 10% floor:
+
+- **Phase 1 (s < 10% of max):** Constant rate at `baseRegenRate * 0.10` (the floor).
+  - Duration: `(max * 0.10) / (baseRegenRate * 0.10)` = `max / baseRegenRate` seconds.
+- **Phase 2 (s >= 10% of max):** Exponential growth: `ds/dt = baseRegenRate * s / max`.
+  - Solution: `s(t) = s0 * e^(baseRegenRate * t / max)`.
+  - Time from 10% to X%: `(max / baseRegenRate) * ln(X / 10)`.
+
+With Knight values (`max = 100`, `baseRegenRate = 40.0`):
+- Phase 1 (0 → 10): `100 / 40 = 2.5s` at constant 4.0/s
+- Phase 2 (10 → 50): `2.5 * ln(5) ≈ 4.0s`
+- Phase 2 (10 → 100): `2.5 * ln(10) ≈ 5.8s`
+- **Total from empty: 1.5s delay + 2.5s + 5.8s ≈ 9.8s** (meets ~10s target)
 
 ---
 
@@ -205,21 +239,28 @@ when player wants to attack and comcon.canPerformAttack():
 
 #### Skill Gating (`triggerSkill`)
 
-Same pattern as attacks:
+Same check-before-consume-after pattern as attacks. Each skill slot is handled separately since the codebase has distinct `canUseAbility1()` / `canUseAbility2()` methods and separate timer fields per slot.
 
-**Before starting a skill:**
+**Before starting a skill (both slots follow this pattern):**
 ```
-when player wants to use ability and comcon.canUseAbility():
-    cost = skillDefinition.staminaCost
+when player wants to use ability1 and comcon.canUseAbility1():
+    cost = comcon.ability1.staminaCost
     if !stamina.canAfford(cost):
         // Silently reject — player cannot use this skill
         return
-    // Proceed with triggerSkill() as normal
+    // Proceed with triggerSkill() for slot 1 as normal
+
+when player wants to use ability2 and comcon.canUseAbility2():
+    cost = comcon.ability2.staminaCost
+    if !stamina.canAfford(cost):
+        return
+    // Proceed with triggerSkill() for slot 2 as normal
 ```
 
 **When cast completes (`tickSkillSlot`):**
 ```
-    cost = skillDefinition.staminaCost
+    // tickSkillSlot already knows which slot it's processing
+    cost = skillDefinition.staminaCost   // ability1 or ability2 respectively
     stamina.consume(cost)
     // Then proceed with executeSkill(), cooldown start, etc. as normal
 ```
@@ -236,8 +277,9 @@ In `processCharacterMovement()`, after determining the player wants to sprint:
 
 ```
 if input.isSprinting:
-    if stamina.current > 0:
-        stamina.consume(sprintCostPerSec * deltaTime)
+    frameCost = stamina.sprintCostPerSec * deltaTime
+    if !stamina.isExhausted() and stamina.canAfford(frameCost):
+        stamina.consume(frameCost)
         // Sprint proceeds normally — apply sprintMultiplier to speed
     else:
         controller.isSprinting = false
@@ -246,7 +288,9 @@ if input.isSprinting:
 
 Sprint is the only action with a **continuous** stamina cost (per-second). All other actions have discrete, one-time costs.
 
-Sprint is forcibly disabled when stamina reaches zero. The player's input still says `isSprinting = true`, but the server overrides it. The client will see the speed change via the snapshot.
+Sprint uses `canAfford(frameCost)` for consistency with all other stamina checks (not a raw `current > 0` comparison). It also checks `isExhausted()` explicitly — this prevents a stutter loop where a player exits exhaustion with a tiny amount of stamina, sprints for one frame, drains to zero, re-enters exhaustion, waits 1.5s, and repeats. By blocking sprint during exhaustion, the player must wait for meaningful stamina to accumulate before sprinting again.
+
+Sprint is forcibly disabled when stamina is insufficient or exhausted. The player's input still says `isSprinting = true`, but the server overrides it. The client will see the speed change via the snapshot.
 
 #### Jump Cost
 
@@ -271,11 +315,19 @@ Jump cost is consumed **immediately** (unlike attacks/skills which defer to comp
 
 ### Snapshot Changes
 
-**C++ side:** The snapshot generation code adds two floats to the per-player data passed through the CXX bridge:
-- `stamina` — current stamina value (`stamina.current`)
-- `max_stamina` — maximum stamina value (`stamina.maximum`)
+Stamina data flows through four layers to reach the client. All four must be updated:
 
-**Rust FFI (`ffi.rs`):** Add fields to `CharacterSnapshot`:
+**1. C++ `CharacterSnapshot` struct (`ArenaGame.hpp`):**
+Add `stamina` and `max_stamina` fields to the `CharacterSnapshot` struct definition (alongside existing `health` and `max_health`).
+
+**2. C++ `ArenaGame::createSnapshot()` (`ArenaGame.hpp`):**
+The `createSnapshot()` method must include `Stamina` in the entity view template and populate the new snapshot fields from `stamina.current` and `stamina.maximum`.
+
+**3. C++ CXX bridge mapping (`cxx_bridge.cpp`):**
+The bridge code that pushes `CharacterSnapshot` fields to the Rust side must include the two new fields in the `push_back` call.
+
+**4. Rust FFI bridge (`ffi.rs`):**
+Add fields to both the CXX bridge struct and the Rust wrapper struct, plus the `From` impl that maps between them:
 ```rust
 pub struct CharacterSnapshot {
     // ... existing fields ...
@@ -284,9 +336,8 @@ pub struct CharacterSnapshot {
 }
 ```
 
-**Rust messages (`messages.rs`):** No new message type. Stamina state rides the existing `Snapshot(GameStateSnapshot)` message sent every tick at 60 Hz. Two extra floats per player is negligible bandwidth overhead (~8 bytes per player per tick).
-
-**Frontend types (`types.ts`):** Add matching fields to `CharacterSnapshot`:
+**5. Frontend types (`types.ts`):**
+Add matching fields to the TypeScript `CharacterSnapshot` interface:
 ```typescript
 export interface CharacterSnapshot {
     // ... existing fields ...
@@ -294,6 +345,8 @@ export interface CharacterSnapshot {
     max_stamina: number;
 }
 ```
+
+**No new message type needed.** Stamina state rides the existing `Snapshot(GameStateSnapshot)` message sent every tick at 60 Hz. Two extra floats per player is negligible bandwidth overhead (~8 bytes per player per tick). `messages.rs` requires no changes — it already references `GameStateSnapshot` which contains `CharacterSnapshot` from `ffi.rs`.
 
 ### No Discrete Stamina Events
 
@@ -327,7 +380,7 @@ When a player dies:
 
 When a player revives:
 - Call `stamina.restore()` — sets `current = maximum`, clears `exhausted` and `drainDelayTimer`.
-- This is added alongside the existing `Health::revive()` call in the respawn logic.
+- This is added alongside the existing `Health::revive()` call in `World::respawnPlayer()` (`game-core/src/core/World.hpp`).
 - Player starts the new life with full stamina, clean state.
 
 ### Game Mode Reset (e.g. round restart)
@@ -344,7 +397,7 @@ Starting tuning values for the Knight class. These are balance numbers intended 
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
 | `maxStamina` | `100.0` | Round number, easy to reason about costs as percentages |
-| `baseRegenRate` | `20.0/s` | At full stamina: 5s from empty to full. Effective range: 2.0/s (10% floor) to 20.0/s (100%) |
+| `baseRegenRate` | `40.0/s` | Max regen at 100% stamina. Effective range: 4.0/s (10% floor) to 40.0/s. See Recovery Math section for derivation |
 | `drainDelaySeconds` | `1.5s` | Punishing but not rage-inducing. Long enough to feel the mistake of full drain |
 | `sprintCostPerSec` | `15.0/s` | ~6.6 seconds of continuous sprint from full. Enough to cross the arena but not endlessly kite |
 | `jumpCost` | `8.0` | ~12 jumps from full. Bunny-hopping burns resources fast |
@@ -365,14 +418,20 @@ Full 3-hit combo = **50 stamina** (half the pool). Two full combos back-to-back 
 | Ability 2 | `30.0` | Heavy commitment, limits follow-up options |
 
 ### Recovery Scenarios
+
+Derived from the piecewise ODE (see Recovery Math section). With `baseRegenRate = 40.0`, `max = 100`:
+- Phase 1 (0 → 10): constant floor rate of 4.0/s → 2.5s
+- Phase 2 (10 → X): exponential `s(t) = 10 * e^(0.4t)`, time = `2.5 * ln(X/10)`
+
 | Scenario | Timeline |
 |----------|----------|
-| Full drain (0%) | 1.5s delay → starts at 10% floor (2.0/s) → ~50% in ~6s → ~100% in ~10s total |
-| Drain to 50% (no depletion) | Immediate regen at 10.0/s → back to full in ~3s |
-| Drain to 25% | Immediate regen at 5.0/s → back to full in ~5s |
-| One combo (50% remaining) | Immediate regen at 10.0/s → full in ~3s |
+| Full drain (0%) | 1.5s delay + 2.5s (floor phase) + 5.8s (exponential phase) ≈ **~10s total** |
+| Full drain → 50% | 1.5s delay + 2.5s + 2.5*ln(5) ≈ **~8s** |
+| Drain to 50% (no depletion) | Immediate exponential regen → 2.5*ln(2) ≈ **~1.7s** |
+| Drain to 25% | Immediate → 2.5*ln(4) ≈ **~3.5s** |
+| One combo (50% remaining) | Same as drain to 50% → **~1.7s** |
 
-The takeaway: **conservative play recovers in seconds, reckless play costs 10+ seconds**. This is the core incentive loop.
+The takeaway: **conservative play (stay above 50%) recovers in under 2 seconds. Full drain costs ~10 seconds.** This is the core incentive loop — the punishment is heavily weighted toward reckless depletion.
 
 ### Future Classes (not yet in codebase)
 
@@ -396,12 +455,13 @@ These are hypothetical examples — actual values would be tuned when the classe
 | File | Change |
 |------|--------|
 | `game-core/src/CharacterPreset.hpp` | Add `StaminaPreset` struct, add `stamina` field to `CharacterPreset` |
-| `game-core/src/Presets.hpp` | Populate `StaminaPreset` values for Knight |
+| `game-core/src/Presets.hpp` | Populate `StaminaPreset` values for Knight, add `staminaCost` to attack stages and skill definitions |
 | `game-core/src/Skills.hpp` | Add `staminaCost` field to `AttackStage` and `SkillDefinition` |
-| `game-core/src/systems/CombatSystem.hpp` | Stamina checks before attacks/skills, consume on completion |
-| `game-core/src/systems/CharacterControllerSystem.hpp` | Sprint drain per frame, jump cost, sprint disable on empty |
-| `game-core/src/systems/SystemManager.hpp` | Register `StaminaSystem` in update loop |
-| `game-core/src/ArenaGame.hpp` | Attach `Stamina` component on entity creation, `restore()` on respawn |
-| `backend/src/game/ffi.rs` | Add `stamina`, `max_stamina` to `CharacterSnapshot` |
-| `backend/src/game/messages.rs` | Add `stamina`, `max_stamina` to snapshot serialization (if separate from ffi) |
+| `game-core/src/systems/CombatSystem.hpp` | Stamina checks before attacks/skills (per slot), consume on completion |
+| `game-core/src/systems/CharacterControllerSystem.hpp` | Sprint drain per frame, jump cost, sprint disable on empty/exhausted |
+| `game-core/src/systems/SystemManager.hpp` | Register `StaminaSystem` in `lateUpdate` phase |
+| `game-core/src/ArenaGame.hpp` | Attach `Stamina` component on entity creation; add `stamina`/`max_stamina` to C++ `CharacterSnapshot` struct; populate fields in `createSnapshot()` (include `Stamina` in entity view) |
+| `game-core/src/cxx_bridge.cpp` | Add `stamina`, `max_stamina` to the CXX bridge `push_back` mapping |
+| `game-core/src/core/World.hpp` | Add `stamina.restore()` alongside `Health::revive()` in `respawnPlayer()` |
+| `backend/src/game/ffi.rs` | Add `stamina`, `max_stamina` to CXX bridge struct, Rust wrapper struct, and `From` impl |
 | `frontend/src/game/types.ts` | Add `stamina`, `max_stamina` to `CharacterSnapshot` interface |

--- a/frontend/src/game/HUD.ts
+++ b/frontend/src/game/HUD.ts
@@ -9,6 +9,7 @@ export class GameHUD {
 	private scene: Scene;
 	private enemyBars: Map<number, { bg: any; fill: any }> = new Map();
 	private localHealthFill: any = null;
+	private localStaminaFill: any = null;
 	private cooldownBars: { attack: any; ability1: any; ability2: any };
 	private getCharPosition: (id: number) => Vector3 | null;
 	private enemyBarObserver: Observer<Scene> | null = null;
@@ -46,7 +47,7 @@ export class GameHUD {
 		localBg.background = '#1a1a1a';
 		localBg.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_CENTER;
 		localBg.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
-		localBg.top = '-28px';
+		localBg.top = '-40px';
 		this.gui.addControl(localBg);
 
 		const localFill = new GUI.Rectangle('local-hp-fill');
@@ -60,6 +61,31 @@ export class GameHUD {
 		localBg.addControl(localFill);
 
 		this.localHealthFill = localFill;
+
+		// Local player stamina bar — below health bar
+		const staminaBg = new GUI.Rectangle('local-stamina-bg');
+		staminaBg.width = '160px';
+		staminaBg.height = '9px';
+		staminaBg.cornerRadius = 3;
+		staminaBg.color = '#00000099';
+		staminaBg.thickness = 1;
+		staminaBg.background = '#1a1a1a';
+		staminaBg.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_CENTER;
+		staminaBg.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
+		staminaBg.top = '-24px';
+		this.gui.addControl(staminaBg);
+
+		const staminaFill = new GUI.Rectangle('local-stamina-fill');
+		staminaFill.width = '100%';
+		staminaFill.height = '100%';
+		staminaFill.cornerRadius = 0;
+		staminaFill.color = 'transparent';
+		staminaFill.thickness = 0;
+		staminaFill.background = '#e0a030';
+		staminaFill.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+		staminaBg.addControl(staminaFill);
+
+		this.localStaminaFill = staminaFill;
 
 		// Cooldown bars — row below health bar
 		const cdContainer = new GUI.StackPanel('cd-container');
@@ -105,6 +131,12 @@ export class GameHUD {
 	updateLocalHealth(pct: number): void {
 		if (this.localHealthFill) {
 			this.localHealthFill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
+		}
+	}
+
+	updateLocalStamina(pct: number): void {
+		if (this.localStaminaFill) {
+			this.localStaminaFill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
 		}
 	}
 

--- a/frontend/src/game/SnapshotProcessor.ts
+++ b/frontend/src/game/SnapshotProcessor.ts
@@ -133,6 +133,10 @@ export class SnapshotProcessor {
 		const healthPct = charData.max_health > 0 ? charData.health / charData.max_health : 0;
 		hud.updateLocalHealth(healthPct);
 
+		// Stamina
+		const staminaPct = charData.max_stamina > 0 ? charData.stamina / charData.max_stamina : 0;
+		hud.updateLocalStamina(staminaPct);
+
 		// Death
 		if (charData.state === CharacterState.Dead && !mgr.localIsDead && mgr.localCharacter) {
 			mgr.localIsDead = true;

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -22,6 +22,9 @@ export interface CharacterSnapshot {
 	ability2_cooldown: number;
 	swing_progress: number;
 	is_grounded: boolean;
+	// Stamina data
+	stamina: number;
+	max_stamina: number;
 }
 
 export interface GameStateSnapshot {

--- a/game-core/src/ArenaGame.hpp
+++ b/game-core/src/ArenaGame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/World.hpp"
+#include "components/Stamina.hpp"
 #include "GameTypes.hpp"
 #include <vector>
 #include <chrono>
@@ -26,6 +27,9 @@ struct CharacterSnapshot {
 	float ability2Cooldown;  // max cooldown duration
 	float swingProgress;     // 0.0–1.0 progress through current attack swing (0 = not attacking)
 	bool isGrounded;         // true if character is on the ground (from physics)
+	// Stamina data for HUD
+	float stamina;
+	float maxStamina;
 
 	CharacterSnapshot() = default;
 };
@@ -204,7 +208,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 		Components::PhysicsBody,
 		Components::Health,
 		Components::CharacterController,
-		Components::CombatController
+		Components::CombatController,
+		Components::Stamina
 	>();
 
 	// Convert entities to character snapshots
@@ -213,7 +218,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 				  Components::PhysicsBody& physics,
 				  Components::Health& health,
 				  Components::CharacterController& controller,
-				  Components::CombatController& combat) {
+				  Components::CombatController& combat,
+				  Components::Stamina& stam) {
 
 		CharacterSnapshot charSnapshot;
 		charSnapshot.playerID = playerInfo.playerID;
@@ -233,6 +239,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 			? combat.swingTimer / combat.currentStage().duration
 			: 0.0f;
 		charSnapshot.isGrounded       = physics.isGrounded;
+		charSnapshot.stamina    = stam.current;
+		charSnapshot.maxStamina = stam.maximum;
 
 		snapshot.characters.push_back(charSnapshot);
 	});

--- a/game-core/src/CharacterPreset.hpp
+++ b/game-core/src/CharacterPreset.hpp
@@ -35,6 +35,14 @@ namespace ArenaGame {
 		float height;
 	};
 
+	struct StaminaPreset {
+		float maxStamina;          // total stamina pool
+		float baseRegenRate;       // max regen per second (at 100% stamina)
+		float drainDelaySeconds;   // seconds of no regen after full depletion
+		float sprintCostPerSec;    // stamina consumed per second while sprinting
+		float jumpCost;            // flat stamina consumed per jump
+	};
+
 	struct CombatPreset {
 		float baseDamage;
 		float damageMultiplier;
@@ -49,6 +57,7 @@ namespace ArenaGame {
 		HealthPreset   health;
 		MovementPreset movement;
 		ColliderPreset collider;
+		StaminaPreset  stamina;
 		CombatPreset   combat;
 	};
 

--- a/game-core/src/Presets.hpp
+++ b/game-core/src/Presets.hpp
@@ -33,6 +33,13 @@ namespace Presets {
 			.radius = 0.45f,
 			.height = 1.9f,            // tall with armor
 		},
+		.stamina = {
+			.maxStamina        = 100.0f,
+			.baseRegenRate     = 40.0f,    // effective: 4.0/s (10% floor) to 40.0/s
+			.drainDelaySeconds = 1.5f,     // pause after full depletion
+			.sprintCostPerSec  = 15.0f,    // ~6.6s of continuous sprint
+			.jumpCost          = 8.0f,     // ~12 jumps from full
+		},
 		.combat = {
 			.baseDamage         = 18.0f,
 			.damageMultiplier   = 1.0f,
@@ -41,18 +48,18 @@ namespace Presets {
 			.attackChain = {
 				// Stage 0 — diagonal slice: quick opener
 				{ .damageMultiplier=0.8f, .range=2.0f, .duration=0.45f,
-				  .movementMultiplier=0.0f, .chainWindow=0.6f },
+				  .movementMultiplier=0.0f, .chainWindow=0.6f, .staminaCost=10.0f },
 				// Stage 1 — horizontal slice: mid combo
 				{ .damageMultiplier=0.9f, .range=2.2f, .duration=0.50f,
-				  .movementMultiplier=0.0f, .chainWindow=0.5f },
+				  .movementMultiplier=0.0f, .chainWindow=0.5f, .staminaCost=15.0f },
 				// Stage 2 — stab: heavy finisher, chain resets (chainWindow=0)
 				{ .damageMultiplier=1.6f, .range=1.8f, .duration=0.60f,
-				  .movementMultiplier=0.0f, .chainWindow=0.0f },
+				  .movementMultiplier=0.0f, .chainWindow=0.0f, .staminaCost=25.0f },
 			},
 			.skill1 = { .params = MeleeAOE{ .range=2.5f, .movementMultiplier=0.0f, .dmgMultiplier=1.8f },
-			            .cooldown=5.0f, .castDuration=0.7f },
+			            .cooldown=5.0f, .castDuration=0.7f, .staminaCost=20.0f },
 			.skill2 = { .params = MeleeAOE{ .range=2.0f, .movementMultiplier=0.7f, .dmgMultiplier=1.5f },
-			            .cooldown=10.0f, .castDuration=0.5f },
+			            .cooldown=10.0f, .castDuration=0.5f, .staminaCost=30.0f },
 		},
 	};
 /*

--- a/game-core/src/Skills.hpp
+++ b/game-core/src/Skills.hpp
@@ -18,6 +18,7 @@ namespace ArenaGame {
 		SkillVariant params;
 		float cooldown     = 0.0f;  // cooldown duration after cast ends
 		float castDuration = 0.0f;  // how long player is locked into this skill
+		float staminaCost  = 0.0f;  // stamina consumed when cast completes
 	};
 
 	struct AttackStage {
@@ -28,6 +29,7 @@ namespace ArenaGame {
 		float chainWindow;            // time after duration expires to press again and continue
 									  // 0 on last stage means chain wraps back to stage 0
 		float attackAngle = 1.047f;   // half-angle in radians (≈60° → 120° frontal cone)
+		float staminaCost  = 0.0f;  // stamina consumed when this swing completes
 	};
 
 } // namespace ArenaGame

--- a/game-core/src/components/Stamina.hpp
+++ b/game-core/src/components/Stamina.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "../CharacterPreset.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace ArenaGame {
+namespace Components {
+
+// =============================================================================
+// Stamina - Resource pool for physical actions (sprint, attack, skill, jump)
+// =============================================================================
+// Pure data component with convenience methods. Mirrors Health pattern.
+//
+// Regen formula (applied by StaminaSystem in lateUpdate):
+//   effectiveRate = max(baseRegenRate * current/maximum, baseRegenRate * 0.10)
+//   → smooth curve: more stamina = faster regen, 10% floor prevents near-zero stall
+//
+// Exhaustion: when current hits 0, drainDelayTimer starts. No regen until it
+// expires. Prevents stutter-loop of drain→regen→drain.
+//
+// Consumption is done by CombatSystem (attacks/skills) and
+// CharacterControllerSystem (sprint/jump). This component only stores state.
+// =============================================================================
+
+struct Stamina {
+	// Pool
+	float current;
+	float maximum;
+
+	// Regen
+	float baseRegenRate;      // max regen/s at 100% stamina
+	float drainDelay;         // configured pause duration after full depletion
+	float drainDelayTimer;    // runtime countdown (0 = not exhausted or delay expired)
+
+	// State
+	bool exhausted;           // true from depletion until drainDelayTimer expires
+
+	// Per-class costs (copied from StaminaPreset at spawn)
+	float sprintCostPerSec;   // continuous drain while sprinting
+	float jumpCost;           // flat cost per jump
+
+	// ── Constructors ────────────────────────────────────────────────────
+
+	Stamina()
+		: current(100.0f)
+		, maximum(100.0f)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	explicit Stamina(float maxStamina)
+		: current(maxStamina)
+		, maximum(maxStamina)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	// ── Queries ─────────────────────────────────────────────────────────
+
+	bool canAfford(float cost) const {
+		return current >= cost;
+	}
+
+	bool isExhausted() const {
+		return exhausted;
+	}
+
+	bool isFull() const {
+		return current >= maximum;
+	}
+
+	float getPercent() const {
+		return maximum > 0.0f ? (current / maximum) : 0.0f;
+	}
+
+	// ── Mutation ─────────────────────────────────────────────────────────
+
+	void consume(float amount) {
+		current = std::max(0.0f, current - amount);
+	}
+
+	void recover(float amount) {
+		current = std::min(current + amount, maximum);
+	}
+
+	void restore() {
+		current = maximum;
+		exhausted = false;
+		drainDelayTimer = 0.0f;
+	}
+
+	// ── Factory ─────────────────────────────────────────────────────────
+
+	static Stamina createFromPreset(const StaminaPreset& preset) {
+		Stamina s;
+		s.maximum          = preset.maxStamina;
+		s.current          = s.maximum;
+		s.baseRegenRate    = preset.baseRegenRate;
+		s.drainDelay       = preset.drainDelaySeconds;
+		s.drainDelayTimer  = 0.0f;
+		s.exhausted        = false;
+		s.sprintCostPerSec = preset.sprintCostPerSec;
+		s.jumpCost         = preset.jumpCost;
+		return s;
+	}
+};
+
+} // namespace Components
+} // namespace ArenaGame

--- a/game-core/src/core/World.hpp
+++ b/game-core/src/core/World.hpp
@@ -5,6 +5,7 @@
 #include "../components/PhysicsBody.hpp"
 #include "../components/Collider.hpp"
 #include "../components/Health.hpp"
+#include "../components/Stamina.hpp"
 #include "../components/CharacterController.hpp"
 #include "../components/CombatController.hpp"
 #include "../components/Tags.hpp"
@@ -21,6 +22,7 @@
 #include "../systems/CollisionSystem.hpp"
 #include "../systems/CombatSystem.hpp"
 #include "../systems/GameModeSystem.hpp"
+#include "../systems/StaminaSystem.hpp"
 
 #include "../ISpawner.hpp"
 #include "../CharacterClassLookup.hpp"
@@ -165,6 +167,7 @@ inline void World::initialize() {
 	auto collisionSystem = std::make_unique<CollisionSystem>();
 	auto combatSystem = std::make_unique<CombatSystem>();
 	auto gameModeSystem = std::make_unique<GameModeSystem>();
+	auto staminaSystem = std::make_unique<StaminaSystem>();
 
 	m_gameManager = createGameManager();
 
@@ -174,6 +177,7 @@ inline void World::initialize() {
 	collisionSystem->setRegistry(&m_registry);
 	combatSystem->setRegistry(&m_registry);
 	gameModeSystem->setRegistry(&m_registry);
+	staminaSystem->setRegistry(&m_registry);
 	gameModeSystem->setSpawner(this);
 
 	// Pass GameManager to systems
@@ -182,6 +186,7 @@ inline void World::initialize() {
 	collisionSystem->setGameManager(m_gameManager);
 	combatSystem->setGameManager(m_gameManager);
 	gameModeSystem->setGameManager(m_gameManager);
+	staminaSystem->setGameManager(m_gameManager);
 
 	// Store raw pointers for convenience
 	m_characterControllerSystem = characterControllerSystem.get();
@@ -196,6 +201,7 @@ inline void World::initialize() {
 	m_systemManager.addSystem(std::move(collisionSystem));
 	m_systemManager.addSystem(std::move(combatSystem));
 	m_systemManager.addSystem(std::move(gameModeSystem));
+	m_systemManager.addSystem(std::move(staminaSystem));
 
 	// Initialize all systems
 	m_systemManager.initialize();
@@ -296,6 +302,7 @@ inline entt::entity World::createActor(const Vector3D& pos, const CharacterPrese
 	m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createFromPreset(preset.movement));
 	m_registry.emplace<Components::Collider>(entity, Components::Collider::createFromPreset(preset.collider, layer));
 	m_registry.emplace<Components::Health>(entity, Components::Health::createFromPreset(preset.health));
+	m_registry.emplace<Components::Stamina>(entity, Components::Stamina::createFromPreset(preset.stamina));
 	m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createFromPreset(preset.combat));
 
 	return entity;
@@ -429,6 +436,8 @@ inline void World::respawnPlayer(entt::entity player, const Vector3D& pos) {
 	if (transform)   transform->setPosition(pos.x, pos.y, pos.z);
 	if (physicsBody) physicsBody->setVelocity(0, 0, 0);
 	if (health)      health->revive();
+	auto* stamina = m_registry.try_get<Components::Stamina>(player);
+	if (stamina) stamina->restore();
 	if (controller) {
 		controller->setState(CharacterState::Idle);
 		controller->canMove = true;

--- a/game-core/src/cxx_bridge.cpp
+++ b/game-core/src/cxx_bridge.cpp
@@ -119,6 +119,8 @@ GameStateSnapshot GameBridge::get_snapshot() const {
             /* ability2_cooldown */ c.ability2Cooldown,
             /* swing_progress    */ c.swingProgress,
             /* is_grounded       */ c.isGrounded,
+            /* stamina           */ c.stamina,
+            /* max_stamina       */ c.maxStamina,
         });
     }
 

--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -4,6 +4,7 @@
 #include "../components/Transform.hpp"
 #include "../components/PhysicsBody.hpp"
 #include "../components/CharacterController.hpp"
+#include "../components/Stamina.hpp"
 #include "../GameTypes.hpp"
 #include "../../entt/entt.hpp"
 
@@ -34,6 +35,7 @@ private:
 		Components::CharacterController& controller,
 		Components::PhysicsBody& physics,
 		Components::Transform& transform,
+		Components::Stamina& stamina,
 		float deltaTime
 	);
 };
@@ -47,13 +49,15 @@ inline void CharacterControllerSystem::earlyUpdate(float deltaTime) {
 	auto view = m_registry->view<
 		Components::CharacterController,
 		Components::PhysicsBody,
-		Components::Transform
+		Components::Transform,
+		Components::Stamina
 	>();
 
 	view.each([&](Components::CharacterController& controller,
 		Components::PhysicsBody& physics,
-		Components::Transform& transform) {
-		processCharacterMovement(controller, physics, transform, deltaTime);
+		Components::Transform& transform,
+		Components::Stamina& stamina) {
+		processCharacterMovement(controller, physics, transform, stamina, deltaTime);
 		});
 }
 
@@ -61,6 +65,7 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	Components::CharacterController& controller,
 	Components::PhysicsBody& physics,
 	Components::Transform& transform,
+	Components::Stamina& stamina,
 	float deltaTime
 ) {
 	// Skip if movement is disabled or dead
@@ -68,8 +73,18 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		return;
 	}
 
-	// Update sprinting state from input
-	controller.isSprinting = controller.input.isSprinting;
+	// Sprint gating: require stamina and not exhausted
+	if (controller.input.isSprinting) {
+		float frameCost = stamina.sprintCostPerSec * deltaTime;
+		if (!stamina.isExhausted() && stamina.canAfford(frameCost)) {
+			stamina.consume(frameCost);
+			controller.isSprinting = true;
+		} else {
+			controller.isSprinting = false;
+		}
+	} else {
+		controller.isSprinting = false;
+	}
 
 	// Get movement input
 	Vector3D moveDir = controller.getMovementDirection();
@@ -104,7 +119,9 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	}
 
 	// Handle jumping
-	if (controller.input.isJumping && controller.canJump && physics.isGrounded) {
+	if (controller.input.isJumping && controller.canJump && physics.isGrounded
+			&& stamina.canAfford(stamina.jumpCost)) {
+		stamina.consume(stamina.jumpCost);
 		physics.velocity.y = controller.jumpVelocity;
 		// Keep state as Moving (no Jumping state in enum)
 	}

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include "../components/PhysicsBody.hpp"
 #include "../components/Health.hpp"
+#include "../components/Stamina.hpp"
 #include "../components/CombatController.hpp"
 #include "../components/CharacterController.hpp"
 #include "../components/GameModeComponent.hpp"
@@ -217,14 +218,15 @@ inline void CombatSystem::processInputAttacks() {
 
 	auto* ne = m_registry->try_get<NetworkEventsComponent>(m_gameManager);
 
-	auto view = m_registry->view<CharacterController, CombatController, Health, Transform, PhysicsBody>();
+	auto view = m_registry->view<CharacterController, CombatController, Health, Transform, PhysicsBody, Stamina>();
 
 	view.each([&](entt::entity entity,
 				  CharacterController& charcon,
 				  CombatController&    comcon,
 				  Health&              health,
 				  Transform&           trans,
-				  PhysicsBody&         physics) {
+				  PhysicsBody&         physics,
+				  Stamina&             stamina) {
 
 		if (!health.isAlive()) return;
 
@@ -240,24 +242,35 @@ inline void CombatSystem::processInputAttacks() {
 		CombatController::BufferedAction toFire = comcon.bufferedAction;
 		comcon.bufferedAction = CombatController::BufferedAction::None;
 
+		// Discard buffered action if stamina is insufficient
+		if (toFire == CombatController::BufferedAction::Attack
+				&& !stamina.canAfford(comcon.currentStage().staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill1
+				&& !stamina.canAfford(comcon.ability1.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill2
+				&& !stamina.canAfford(comcon.ability2.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+
 		const bool wantsAttack = charcon.input.isAttacking     || toFire == CombatController::BufferedAction::Attack;
 		const bool wantsSkill1 = charcon.input.isUsingAbility1 || toFire == CombatController::BufferedAction::Skill1;
 		const bool wantsSkill2 = charcon.input.isUsingAbility2 || toFire == CombatController::BufferedAction::Skill2;
 
 		// Priority: Skill2 > Skill1 > Attack
-		if (wantsSkill2 && comcon.canUseAbility2()) {
+		if (wantsSkill2 && comcon.canUseAbility2() && stamina.canAfford(comcon.ability2.staminaCost)) {
 			fprintf(stderr, "[COMBAT] ABILITY2 entity=%u  cd=%.2f\n",
 				static_cast<unsigned>(entity), static_cast<double>(comcon.skill2CooldownTimer));
 			triggerSkill(comcon, charcon, comcon.ability2,
 			             comcon.skill2CastTimer, comcon.skill2HitPending, ne, entity, 2);
 
-		} else if (wantsSkill1 && comcon.canUseAbility1()) {
+		} else if (wantsSkill1 && comcon.canUseAbility1() && stamina.canAfford(comcon.ability1.staminaCost)) {
 			fprintf(stderr, "[COMBAT] ABILITY1 entity=%u  cd=%.2f\n",
 				static_cast<unsigned>(entity), static_cast<double>(comcon.skill1CooldownTimer));
 			triggerSkill(comcon, charcon, comcon.ability1,
 			             comcon.skill1CastTimer, comcon.skill1HitPending, ne, entity, 1);
 
-		} else if (wantsAttack && comcon.canPerformAttack()) {
+		} else if (wantsAttack && comcon.canPerformAttack() && stamina.canAfford(comcon.currentStage().staminaCost)) {
 			const AttackStage& stage = comcon.currentStage();
 			fprintf(stderr, "[COMBAT] ATTACK  entity=%u  chain_stage=%d  range=%.1f  dmg_mul=%.2f  base_dmg=%.1f\n",
 				static_cast<unsigned>(entity), comcon.chainStage,
@@ -419,6 +432,9 @@ inline void CombatSystem::handleSwingEnd(
 		if (health.isAlive()) {
 			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
 			const AttackStage& stage = combat.currentStage();
+			// Consume stamina for this swing stage (read BEFORE advanceChain)
+			if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+				stamina->consume(stage.staminaCost);
 			hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
 			combat.advanceChain();
 			fprintf(stderr, "[COMBAT] deferred_hit applied  next_chain_stage=%d\n", combat.chainStage);
@@ -451,6 +467,9 @@ inline void CombatSystem::tickSkillSlot(
 	cooldownTimer = def.cooldown;
 
 	if (hitPending) {
+		// Consume stamina when cast completes
+		if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+			stamina->consume(def.staminaCost);
 		if (health.isAlive()) {
 			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
 			executeSkill(def, ctx);

--- a/game-core/src/systems/StaminaSystem.hpp
+++ b/game-core/src/systems/StaminaSystem.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "System.hpp"
+#include "../components/Stamina.hpp"
+#include "../components/CharacterController.hpp"
+#include "../components/CombatController.hpp"
+#include "../components/Health.hpp"
+#include "../../entt/entt.hpp"
+#include <algorithm>
+
+namespace ArenaGame {
+
+// =============================================================================
+// StaminaSystem - Stamina regeneration (runs in lateUpdate)
+// =============================================================================
+// Sole owner of regen logic. Does NOT consume stamina — that is done by
+// CombatSystem (attacks/skills) and CharacterControllerSystem (sprint/jump).
+//
+// Responsibilities:
+//   1. Detect full depletion → set exhausted flag + start drain delay timer
+//   2. Tick drain delay timer during exhaustion
+//   3. Clear exhaustion when delay expires
+//   4. Apply scaled regen when player is not actively consuming stamina
+//
+// Regen formula:
+//   effectiveRate = max(baseRegenRate * (current / maximum), baseRegenRate * 0.10)
+//   → 10% floor prevents infinitely slow recovery near zero
+//
+// Runs in lateUpdate (after CharacterControllerSystem in earlyUpdate and
+// CombatSystem in update) so all consumption for the current frame is already
+// applied before regen ticks.
+// =============================================================================
+
+class StaminaSystem : public System {
+public:
+	StaminaSystem() = default;
+
+	void lateUpdate(float deltaTime) override;
+	const char* getName() const override { return "StaminaSystem"; }
+	bool needsLateUpdate() const override { return true; }
+	bool needsUpdate() const override { return false; }
+};
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+inline void StaminaSystem::lateUpdate(float deltaTime) {
+	auto view = m_registry->view<
+		Components::Stamina,
+		Components::CharacterController,
+		Components::CombatController,
+		Components::Health
+	>();
+
+	view.each([&](Components::Stamina& stamina,
+				  Components::CharacterController& controller,
+				  Components::CombatController& combat,
+				  Components::Health& health) {
+
+		// 1. Dead players don't regen
+		if (!health.isAlive()) return;
+
+		// 2. Detect full depletion → enter exhaustion
+		if (stamina.current <= 0.0f && !stamina.exhausted) {
+			stamina.exhausted = true;
+			stamina.drainDelayTimer = stamina.drainDelay;
+		}
+
+		// 3. Tick drain delay during exhaustion
+		if (stamina.exhausted) {
+			stamina.drainDelayTimer -= deltaTime;
+			if (stamina.drainDelayTimer <= 0.0f) {
+				stamina.exhausted = false;
+				stamina.drainDelayTimer = 0.0f;
+			} else {
+				return;  // no regen during drain delay
+			}
+		}
+
+		// 4. No regen while actively spending stamina
+		if (controller.isSprinting) return;
+		if (combat.isAttacking) return;
+		if (combat.isAbility1Casting()) return;
+		if (combat.isAbility2Casting()) return;
+
+		// 5. Scaled regen with 10% minimum floor
+		float ratio = stamina.current / stamina.maximum;
+		float effectiveRate = stamina.baseRegenRate * ratio;
+		effectiveRate = std::max(effectiveRate, stamina.baseRegenRate * 0.10f);
+
+		stamina.current = std::min(stamina.current + effectiveRate * deltaTime, stamina.maximum);
+	});
+}
+
+} // namespace ArenaGame


### PR DESCRIPTION
Add stamina system with sprint/combat gating and HUD bar

- Adds a full stamina ECS system to the C++ game engine — stamina component, regen 
  with scaled recovery, exhaustion threshold, and per-character presets (Knight wired
   up)                                                                               
  - Gates sprinting and jumping behind stamina cost checks; attacks and skills deduct
   stamina with insufficient-stamina blocking                                        
  - Pipes stamina/max_stamina through the C++ snapshot → CXX bridge → Rust FFI →
  frontend types → Babylon.js HUD, rendering an amber stamina bar below the health   
  bar             
                                                                                     
  Changes         

  Game engine (C++)
  - Stamina component with current/max, regen rate, exhaustion flag, and cost config
  - StaminaSystem ticked each frame — handles regen, drain, and exhaustion state     
  - CombatSystem checks stamina before attacks/skills and deducts on use        
  - CharacterControllerSystem drains stamina on sprint/jump, blocks when exhausted   
  - StaminaPreset added to CharacterPreset; Knight preset populated                  
                                                                                     
  Backend (Rust)                                                                     
  - stamina and max_stamina fields added to the FFI bridge struct and Rust wrapper   
                                                                                     
  Frontend (TypeScript)
  - CharacterSnapshot type extended with stamina fields                              
  - HUD.ts renders a stamina bar (160×9px, amber fill) below the health bar          
  - SnapshotProcessor.ts updates stamina bar each frame                    
                                                                                     
  Test plan                                                                          
                                                                                     
  - Start a game as Knight — stamina bar appears below health bar, full amber        
  - Hold sprint — stamina drains visibly; release — it regens
  - Drain stamina fully — sprinting and jumping are blocked until recovery passes    
  exhaustion threshold                                                               
  - Attack/use abilities — stamina deducts per swing; attacks blocked when stamina   
  insufficient                                                                       
  - Verify enemy players don't show a stamina bar (stamina is local-only HUD)