### PR TITLE
Feat/game stamina system

### DIFF
--- a/backend/src/game/ffi.rs
+++ b/backend/src/game/ffi.rs
@@ -54,6 +54,8 @@ mod bridge {
         ability2_cooldown: f32,
         swing_progress: f32,
         is_grounded: bool,
+        stamina: f32,
+        max_stamina: f32,
     }
 
     struct GameStateSnapshot {
@@ -211,6 +213,8 @@ pub struct CharacterSnapshot {
     pub ability2_cooldown: f32,
     pub swing_progress: f32,
     pub is_grounded: bool,
+    pub stamina: f32,
+    pub max_stamina: f32,
 }
 
 impl From<bridge::CharacterSnapshot> for CharacterSnapshot {
@@ -237,6 +241,8 @@ impl From<bridge::CharacterSnapshot> for CharacterSnapshot {
             ability2_cooldown: c.ability2_cooldown,
             swing_progress: c.swing_progress,
             is_grounded: c.is_grounded,
+            stamina: c.stamina,
+            max_stamina: c.max_stamina,
         }
     }
 }

--- a/frontend/src/game/HUD.ts
+++ b/frontend/src/game/HUD.ts
@@ -9,6 +9,7 @@ export class GameHUD {
 	private scene: Scene;
 	private enemyBars: Map<number, { bg: any; fill: any }> = new Map();
 	private localHealthFill: any = null;
+	private localStaminaFill: any = null;
 	private cooldownBars: { attack: any; ability1: any; ability2: any };
 	private getCharPosition: (id: number) => Vector3 | null;
 	private enemyBarObserver: Observer<Scene> | null = null;
@@ -46,7 +47,7 @@ export class GameHUD {
 		localBg.background = '#1a1a1a';
 		localBg.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_CENTER;
 		localBg.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
-		localBg.top = '-28px';
+		localBg.top = '-40px';
 		this.gui.addControl(localBg);
 
 		const localFill = new GUI.Rectangle('local-hp-fill');
@@ -60,6 +61,31 @@ export class GameHUD {
 		localBg.addControl(localFill);
 
 		this.localHealthFill = localFill;
+
+		// Local player stamina bar — below health bar
+		const staminaBg = new GUI.Rectangle('local-stamina-bg');
+		staminaBg.width = '160px';
+		staminaBg.height = '9px';
+		staminaBg.cornerRadius = 3;
+		staminaBg.color = '#00000099';
+		staminaBg.thickness = 1;
+		staminaBg.background = '#1a1a1a';
+		staminaBg.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_CENTER;
+		staminaBg.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_BOTTOM;
+		staminaBg.top = '-24px';
+		this.gui.addControl(staminaBg);
+
+		const staminaFill = new GUI.Rectangle('local-stamina-fill');
+		staminaFill.width = '100%';
+		staminaFill.height = '100%';
+		staminaFill.cornerRadius = 0;
+		staminaFill.color = 'transparent';
+		staminaFill.thickness = 0;
+		staminaFill.background = '#e0a030';
+		staminaFill.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+		staminaBg.addControl(staminaFill);
+
+		this.localStaminaFill = staminaFill;
 
 		// Cooldown bars — row below health bar
 		const cdContainer = new GUI.StackPanel('cd-container');
@@ -105,6 +131,12 @@ export class GameHUD {
 	updateLocalHealth(pct: number): void {
 		if (this.localHealthFill) {
 			this.localHealthFill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
+		}
+	}
+
+	updateLocalStamina(pct: number): void {
+		if (this.localStaminaFill) {
+			this.localStaminaFill.width = `${(Math.max(0, Math.min(1, pct)) * 100).toFixed(1)}%`;
 		}
 	}
 

--- a/frontend/src/game/SnapshotProcessor.ts
+++ b/frontend/src/game/SnapshotProcessor.ts
@@ -133,6 +133,10 @@ export class SnapshotProcessor {
 		const healthPct = charData.max_health > 0 ? charData.health / charData.max_health : 0;
 		hud.updateLocalHealth(healthPct);
 
+		// Stamina
+		const staminaPct = charData.max_stamina > 0 ? charData.stamina / charData.max_stamina : 0;
+		hud.updateLocalStamina(staminaPct);
+
 		// Death
 		if (charData.state === CharacterState.Dead && !mgr.localIsDead && mgr.localCharacter) {
 			mgr.localIsDead = true;

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -22,6 +22,9 @@ export interface CharacterSnapshot {
 	ability2_cooldown: number;
 	swing_progress: number;
 	is_grounded: boolean;
+	// Stamina data
+	stamina: number;
+	max_stamina: number;
 }
 
 export interface GameStateSnapshot {

--- a/game-core/src/ArenaGame.hpp
+++ b/game-core/src/ArenaGame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/World.hpp"
+#include "components/Stamina.hpp"
 #include "GameTypes.hpp"
 #include <vector>
 #include <chrono>
@@ -26,6 +27,9 @@ struct CharacterSnapshot {
 	float ability2Cooldown;  // max cooldown duration
 	float swingProgress;     // 0.0–1.0 progress through current attack swing (0 = not attacking)
 	bool isGrounded;         // true if character is on the ground (from physics)
+	// Stamina data for HUD
+	float stamina;
+	float maxStamina;
 
 	CharacterSnapshot() = default;
 };
@@ -204,7 +208,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 		Components::PhysicsBody,
 		Components::Health,
 		Components::CharacterController,
-		Components::CombatController
+		Components::CombatController,
+		Components::Stamina
 	>();
 
 	// Convert entities to character snapshots
@@ -213,7 +218,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 				  Components::PhysicsBody& physics,
 				  Components::Health& health,
 				  Components::CharacterController& controller,
-				  Components::CombatController& combat) {
+				  Components::CombatController& combat,
+				  Components::Stamina& stam) {
 
 		CharacterSnapshot charSnapshot;
 		charSnapshot.playerID = playerInfo.playerID;
@@ -233,6 +239,8 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 			? combat.swingTimer / combat.currentStage().duration
 			: 0.0f;
 		charSnapshot.isGrounded       = physics.isGrounded;
+		charSnapshot.stamina    = stam.current;
+		charSnapshot.maxStamina = stam.maximum;
 
 		snapshot.characters.push_back(charSnapshot);
 	});

--- a/game-core/src/CharacterPreset.hpp
+++ b/game-core/src/CharacterPreset.hpp
@@ -35,6 +35,14 @@ namespace ArenaGame {
 		float height;
 	};
 
+	struct StaminaPreset {
+		float maxStamina;          // total stamina pool
+		float baseRegenRate;       // max regen per second (at 100% stamina)
+		float drainDelaySeconds;   // seconds of no regen after full depletion
+		float sprintCostPerSec;    // stamina consumed per second while sprinting
+		float jumpCost;            // flat stamina consumed per jump
+	};
+
 	struct CombatPreset {
 		float baseDamage;
 		float damageMultiplier;
@@ -49,6 +57,7 @@ namespace ArenaGame {
 		HealthPreset   health;
 		MovementPreset movement;
 		ColliderPreset collider;
+		StaminaPreset  stamina;
 		CombatPreset   combat;
 	};
 

--- a/game-core/src/Presets.hpp
+++ b/game-core/src/Presets.hpp
@@ -33,6 +33,13 @@ namespace Presets {
 			.radius = 0.45f,
 			.height = 1.9f,            // tall with armor
 		},
+		.stamina = {
+			.maxStamina        = 100.0f,
+			.baseRegenRate     = 40.0f,    // effective: 4.0/s (10% floor) to 40.0/s
+			.drainDelaySeconds = 1.5f,     // pause after full depletion
+			.sprintCostPerSec  = 15.0f,    // ~6.6s of continuous sprint
+			.jumpCost          = 8.0f,     // ~12 jumps from full
+		},
 		.combat = {
 			.baseDamage         = 18.0f,
 			.damageMultiplier   = 1.0f,
@@ -41,18 +48,18 @@ namespace Presets {
 			.attackChain = {
 				// Stage 0 — diagonal slice: quick opener
 				{ .damageMultiplier=0.8f, .range=2.0f, .duration=0.45f,
-				  .movementMultiplier=0.0f, .chainWindow=0.6f },
+				  .movementMultiplier=0.0f, .chainWindow=0.6f, .staminaCost=10.0f },
 				// Stage 1 — horizontal slice: mid combo
 				{ .damageMultiplier=0.9f, .range=2.2f, .duration=0.50f,
-				  .movementMultiplier=0.0f, .chainWindow=0.5f },
+				  .movementMultiplier=0.0f, .chainWindow=0.5f, .staminaCost=15.0f },
 				// Stage 2 — stab: heavy finisher, chain resets (chainWindow=0)
 				{ .damageMultiplier=1.6f, .range=1.8f, .duration=0.60f,
-				  .movementMultiplier=0.0f, .chainWindow=0.0f },
+				  .movementMultiplier=0.0f, .chainWindow=0.0f, .staminaCost=25.0f },
 			},
 			.skill1 = { .params = MeleeAOE{ .range=2.5f, .movementMultiplier=0.0f, .dmgMultiplier=1.8f },
-			            .cooldown=5.0f, .castDuration=0.7f },
+			            .cooldown=5.0f, .castDuration=0.7f, .staminaCost=20.0f },
 			.skill2 = { .params = MeleeAOE{ .range=2.0f, .movementMultiplier=0.7f, .dmgMultiplier=1.5f },
-			            .cooldown=10.0f, .castDuration=0.5f },
+			            .cooldown=10.0f, .castDuration=0.5f, .staminaCost=30.0f },
 		},
 	};
 /*

--- a/game-core/src/Skills.hpp
+++ b/game-core/src/Skills.hpp
@@ -18,6 +18,7 @@ namespace ArenaGame {
 		SkillVariant params;
 		float cooldown     = 0.0f;  // cooldown duration after cast ends
 		float castDuration = 0.0f;  // how long player is locked into this skill
+		float staminaCost  = 0.0f;  // stamina consumed when cast completes
 	};
 
 	struct AttackStage {
@@ -28,6 +29,7 @@ namespace ArenaGame {
 		float chainWindow;            // time after duration expires to press again and continue
 									  // 0 on last stage means chain wraps back to stage 0
 		float attackAngle = 1.047f;   // half-angle in radians (≈60° → 120° frontal cone)
+		float staminaCost  = 0.0f;  // stamina consumed when this swing completes
 	};
 
 } // namespace ArenaGame

--- a/game-core/src/components/Stamina.hpp
+++ b/game-core/src/components/Stamina.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "../CharacterPreset.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace ArenaGame {
+namespace Components {
+
+// =============================================================================
+// Stamina - Resource pool for physical actions (sprint, attack, skill, jump)
+// =============================================================================
+// Pure data component with convenience methods. Mirrors Health pattern.
+//
+// Regen formula (applied by StaminaSystem in lateUpdate):
+//   effectiveRate = max(baseRegenRate * current/maximum, baseRegenRate * 0.10)
+//   → smooth curve: more stamina = faster regen, 10% floor prevents near-zero stall
+//
+// Exhaustion: when current hits 0, drainDelayTimer starts. No regen until it
+// expires. Prevents stutter-loop of drain→regen→drain.
+//
+// Consumption is done by CombatSystem (attacks/skills) and
+// CharacterControllerSystem (sprint/jump). This component only stores state.
+// =============================================================================
+
+struct Stamina {
+	// Pool
+	float current;
+	float maximum;
+
+	// Regen
+	float baseRegenRate;      // max regen/s at 100% stamina
+	float drainDelay;         // configured pause duration after full depletion
+	float drainDelayTimer;    // runtime countdown (0 = not exhausted or delay expired)
+
+	// State
+	bool exhausted;           // true from depletion until drainDelayTimer expires
+
+	// Per-class costs (copied from StaminaPreset at spawn)
+	float sprintCostPerSec;   // continuous drain while sprinting
+	float jumpCost;           // flat cost per jump
+
+	// ── Constructors ────────────────────────────────────────────────────
+
+	Stamina()
+		: current(100.0f)
+		, maximum(100.0f)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	explicit Stamina(float maxStamina)
+		: current(maxStamina)
+		, maximum(maxStamina)
+		, baseRegenRate(40.0f)
+		, drainDelay(1.5f)
+		, drainDelayTimer(0.0f)
+		, exhausted(false)
+		, sprintCostPerSec(15.0f)
+		, jumpCost(8.0f)
+	{}
+
+	// ── Queries ─────────────────────────────────────────────────────────
+
+	bool canAfford(float cost) const {
+		return current >= cost;
+	}
+
+	bool isExhausted() const {
+		return exhausted;
+	}
+
+	bool isFull() const {
+		return current >= maximum;
+	}
+
+	float getPercent() const {
+		return maximum > 0.0f ? (current / maximum) : 0.0f;
+	}
+
+	// ── Mutation ─────────────────────────────────────────────────────────
+
+	void consume(float amount) {
+		current = std::max(0.0f, current - amount);
+	}
+
+	void recover(float amount) {
+		current = std::min(current + amount, maximum);
+	}
+
+	void restore() {
+		current = maximum;
+		exhausted = false;
+		drainDelayTimer = 0.0f;
+	}
+
+	// ── Factory ─────────────────────────────────────────────────────────
+
+	static Stamina createFromPreset(const StaminaPreset& preset) {
+		Stamina s;
+		s.maximum          = preset.maxStamina;
+		s.current          = s.maximum;
+		s.baseRegenRate    = preset.baseRegenRate;
+		s.drainDelay       = preset.drainDelaySeconds;
+		s.drainDelayTimer  = 0.0f;
+		s.exhausted        = false;
+		s.sprintCostPerSec = preset.sprintCostPerSec;
+		s.jumpCost         = preset.jumpCost;
+		return s;
+	}
+};
+
+} // namespace Components
+} // namespace ArenaGame

--- a/game-core/src/core/World.hpp
+++ b/game-core/src/core/World.hpp
@@ -5,6 +5,7 @@
 #include "../components/PhysicsBody.hpp"
 #include "../components/Collider.hpp"
 #include "../components/Health.hpp"
+#include "../components/Stamina.hpp"
 #include "../components/CharacterController.hpp"
 #include "../components/CombatController.hpp"
 #include "../components/Tags.hpp"
@@ -21,6 +22,7 @@
 #include "../systems/CollisionSystem.hpp"
 #include "../systems/CombatSystem.hpp"
 #include "../systems/GameModeSystem.hpp"
+#include "../systems/StaminaSystem.hpp"
 
 #include "../ISpawner.hpp"
 #include "../CharacterClassLookup.hpp"
@@ -165,6 +167,7 @@ inline void World::initialize() {
 	auto collisionSystem = std::make_unique<CollisionSystem>();
 	auto combatSystem = std::make_unique<CombatSystem>();
 	auto gameModeSystem = std::make_unique<GameModeSystem>();
+	auto staminaSystem = std::make_unique<StaminaSystem>();
 
 	m_gameManager = createGameManager();
 
@@ -174,6 +177,7 @@ inline void World::initialize() {
 	collisionSystem->setRegistry(&m_registry);
 	combatSystem->setRegistry(&m_registry);
 	gameModeSystem->setRegistry(&m_registry);
+	staminaSystem->setRegistry(&m_registry);
 	gameModeSystem->setSpawner(this);
 
 	// Pass GameManager to systems
@@ -182,6 +186,7 @@ inline void World::initialize() {
 	collisionSystem->setGameManager(m_gameManager);
 	combatSystem->setGameManager(m_gameManager);
 	gameModeSystem->setGameManager(m_gameManager);
+	staminaSystem->setGameManager(m_gameManager);
 
 	// Store raw pointers for convenience
 	m_characterControllerSystem = characterControllerSystem.get();
@@ -196,6 +201,7 @@ inline void World::initialize() {
 	m_systemManager.addSystem(std::move(collisionSystem));
 	m_systemManager.addSystem(std::move(combatSystem));
 	m_systemManager.addSystem(std::move(gameModeSystem));
+	m_systemManager.addSystem(std::move(staminaSystem));
 
 	// Initialize all systems
 	m_systemManager.initialize();
@@ -296,6 +302,7 @@ inline entt::entity World::createActor(const Vector3D& pos, const CharacterPrese
 	m_registry.emplace<Components::PhysicsBody>(entity, Components::PhysicsBody::createFromPreset(preset.movement));
 	m_registry.emplace<Components::Collider>(entity, Components::Collider::createFromPreset(preset.collider, layer));
 	m_registry.emplace<Components::Health>(entity, Components::Health::createFromPreset(preset.health));
+	m_registry.emplace<Components::Stamina>(entity, Components::Stamina::createFromPreset(preset.stamina));
 	m_registry.emplace<Components::CombatController>(entity, Components::CombatController::createFromPreset(preset.combat));
 
 	return entity;
@@ -429,6 +436,8 @@ inline void World::respawnPlayer(entt::entity player, const Vector3D& pos) {
 	if (transform)   transform->setPosition(pos.x, pos.y, pos.z);
 	if (physicsBody) physicsBody->setVelocity(0, 0, 0);
 	if (health)      health->revive();
+	auto* stamina = m_registry.try_get<Components::Stamina>(player);
+	if (stamina) stamina->restore();
 	if (controller) {
 		controller->setState(CharacterState::Idle);
 		controller->canMove = true;

--- a/game-core/src/cxx_bridge.cpp
+++ b/game-core/src/cxx_bridge.cpp
@@ -119,6 +119,8 @@ GameStateSnapshot GameBridge::get_snapshot() const {
             /* ability2_cooldown */ c.ability2Cooldown,
             /* swing_progress    */ c.swingProgress,
             /* is_grounded       */ c.isGrounded,
+            /* stamina           */ c.stamina,
+            /* max_stamina       */ c.maxStamina,
         });
     }
 

--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -4,6 +4,7 @@
 #include "../components/Transform.hpp"
 #include "../components/PhysicsBody.hpp"
 #include "../components/CharacterController.hpp"
+#include "../components/Stamina.hpp"
 #include "../GameTypes.hpp"
 #include "../../entt/entt.hpp"
 
@@ -34,6 +35,7 @@ private:
 		Components::CharacterController& controller,
 		Components::PhysicsBody& physics,
 		Components::Transform& transform,
+		Components::Stamina& stamina,
 		float deltaTime
 	);
 };
@@ -47,13 +49,15 @@ inline void CharacterControllerSystem::earlyUpdate(float deltaTime) {
 	auto view = m_registry->view<
 		Components::CharacterController,
 		Components::PhysicsBody,
-		Components::Transform
+		Components::Transform,
+		Components::Stamina
 	>();
 
 	view.each([&](Components::CharacterController& controller,
 		Components::PhysicsBody& physics,
-		Components::Transform& transform) {
-		processCharacterMovement(controller, physics, transform, deltaTime);
+		Components::Transform& transform,
+		Components::Stamina& stamina) {
+		processCharacterMovement(controller, physics, transform, stamina, deltaTime);
 		});
 }
 
@@ -61,6 +65,7 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	Components::CharacterController& controller,
 	Components::PhysicsBody& physics,
 	Components::Transform& transform,
+	Components::Stamina& stamina,
 	float deltaTime
 ) {
 	// Skip if movement is disabled or dead
@@ -68,8 +73,18 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		return;
 	}
 
-	// Update sprinting state from input
-	controller.isSprinting = controller.input.isSprinting;
+	// Sprint gating: require stamina and not exhausted
+	if (controller.input.isSprinting) {
+		float frameCost = stamina.sprintCostPerSec * deltaTime;
+		if (!stamina.isExhausted() && stamina.canAfford(frameCost)) {
+			stamina.consume(frameCost);
+			controller.isSprinting = true;
+		} else {
+			controller.isSprinting = false;
+		}
+	} else {
+		controller.isSprinting = false;
+	}
 
 	// Get movement input
 	Vector3D moveDir = controller.getMovementDirection();
@@ -104,7 +119,9 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	}
 
 	// Handle jumping
-	if (controller.input.isJumping && controller.canJump && physics.isGrounded) {
+	if (controller.input.isJumping && controller.canJump && physics.isGrounded
+			&& stamina.canAfford(stamina.jumpCost)) {
+		stamina.consume(stamina.jumpCost);
 		physics.velocity.y = controller.jumpVelocity;
 		// Keep state as Moving (no Jumping state in enum)
 	}

--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -105,7 +105,7 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		}
 
 		// Update state
-		controller.setState(controller.input.isSprinting
+		controller.setState(controller.isSprinting
 			? CharacterState::Sprinting
 			: CharacterState::Walking);
 	} else {

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include "../components/PhysicsBody.hpp"
 #include "../components/Health.hpp"
+#include "../components/Stamina.hpp"
 #include "../components/CombatController.hpp"
 #include "../components/CharacterController.hpp"
 #include "../components/GameModeComponent.hpp"
@@ -217,14 +218,15 @@ inline void CombatSystem::processInputAttacks() {
 
 	auto* ne = m_registry->try_get<NetworkEventsComponent>(m_gameManager);
 
-	auto view = m_registry->view<CharacterController, CombatController, Health, Transform, PhysicsBody>();
+	auto view = m_registry->view<CharacterController, CombatController, Health, Transform, PhysicsBody, Stamina>();
 
 	view.each([&](entt::entity entity,
 				  CharacterController& charcon,
 				  CombatController&    comcon,
 				  Health&              health,
 				  Transform&           trans,
-				  PhysicsBody&         physics) {
+				  PhysicsBody&         physics,
+				  Stamina&             stamina) {
 
 		if (!health.isAlive()) return;
 
@@ -240,24 +242,35 @@ inline void CombatSystem::processInputAttacks() {
 		CombatController::BufferedAction toFire = comcon.bufferedAction;
 		comcon.bufferedAction = CombatController::BufferedAction::None;
 
+		// Discard buffered action if stamina is insufficient
+		if (toFire == CombatController::BufferedAction::Attack
+				&& !stamina.canAfford(comcon.currentStage().staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill1
+				&& !stamina.canAfford(comcon.ability1.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+		if (toFire == CombatController::BufferedAction::Skill2
+				&& !stamina.canAfford(comcon.ability2.staminaCost))
+			toFire = CombatController::BufferedAction::None;
+
 		const bool wantsAttack = charcon.input.isAttacking     || toFire == CombatController::BufferedAction::Attack;
 		const bool wantsSkill1 = charcon.input.isUsingAbility1 || toFire == CombatController::BufferedAction::Skill1;
 		const bool wantsSkill2 = charcon.input.isUsingAbility2 || toFire == CombatController::BufferedAction::Skill2;
 
 		// Priority: Skill2 > Skill1 > Attack
-		if (wantsSkill2 && comcon.canUseAbility2()) {
+		if (wantsSkill2 && comcon.canUseAbility2() && stamina.canAfford(comcon.ability2.staminaCost)) {
 			fprintf(stderr, "[COMBAT] ABILITY2 entity=%u  cd=%.2f\n",
 				static_cast<unsigned>(entity), static_cast<double>(comcon.skill2CooldownTimer));
 			triggerSkill(comcon, charcon, comcon.ability2,
 			             comcon.skill2CastTimer, comcon.skill2HitPending, ne, entity, 2);
 
-		} else if (wantsSkill1 && comcon.canUseAbility1()) {
+		} else if (wantsSkill1 && comcon.canUseAbility1() && stamina.canAfford(comcon.ability1.staminaCost)) {
 			fprintf(stderr, "[COMBAT] ABILITY1 entity=%u  cd=%.2f\n",
 				static_cast<unsigned>(entity), static_cast<double>(comcon.skill1CooldownTimer));
 			triggerSkill(comcon, charcon, comcon.ability1,
 			             comcon.skill1CastTimer, comcon.skill1HitPending, ne, entity, 1);
 
-		} else if (wantsAttack && comcon.canPerformAttack()) {
+		} else if (wantsAttack && comcon.canPerformAttack() && stamina.canAfford(comcon.currentStage().staminaCost)) {
 			const AttackStage& stage = comcon.currentStage();
 			fprintf(stderr, "[COMBAT] ATTACK  entity=%u  chain_stage=%d  range=%.1f  dmg_mul=%.2f  base_dmg=%.1f\n",
 				static_cast<unsigned>(entity), comcon.chainStage,
@@ -419,6 +432,9 @@ inline void CombatSystem::handleSwingEnd(
 		if (health.isAlive()) {
 			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
 			const AttackStage& stage = combat.currentStage();
+			// Consume stamina for this swing stage (read BEFORE advanceChain)
+			if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+				stamina->consume(stage.staminaCost);
 			hitInArc(ctx, stage.range, stage.damageMultiplier, stage.attackAngle);
 			combat.advanceChain();
 			fprintf(stderr, "[COMBAT] deferred_hit applied  next_chain_stage=%d\n", combat.chainStage);
@@ -451,6 +467,9 @@ inline void CombatSystem::tickSkillSlot(
 	cooldownTimer = def.cooldown;
 
 	if (hitPending) {
+		// Consume stamina when cast completes
+		if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
+			stamina->consume(def.staminaCost);
 		if (health.isAlive()) {
 			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
 			executeSkill(def, ctx);

--- a/game-core/src/systems/StaminaSystem.hpp
+++ b/game-core/src/systems/StaminaSystem.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "System.hpp"
+#include "../components/Stamina.hpp"
+#include "../components/CharacterController.hpp"
+#include "../components/CombatController.hpp"
+#include "../components/Health.hpp"
+#include "../../entt/entt.hpp"
+#include <algorithm>
+
+namespace ArenaGame {
+
+// =============================================================================
+// StaminaSystem - Stamina regeneration (runs in lateUpdate)
+// =============================================================================
+// Sole owner of regen logic. Does NOT consume stamina — that is done by
+// CombatSystem (attacks/skills) and CharacterControllerSystem (sprint/jump).
+//
+// Responsibilities:
+//   1. Detect full depletion → set exhausted flag + start drain delay timer
+//   2. Tick drain delay timer during exhaustion
+//   3. Clear exhaustion when delay expires
+//   4. Apply scaled regen when player is not actively consuming stamina
+//
+// Regen formula:
+//   effectiveRate = max(baseRegenRate * (current / maximum), baseRegenRate * 0.10)
+//   → 10% floor prevents infinitely slow recovery near zero
+//
+// Runs in lateUpdate (after CharacterControllerSystem in earlyUpdate and
+// CombatSystem in update) so all consumption for the current frame is already
+// applied before regen ticks.
+// =============================================================================
+
+class StaminaSystem : public System {
+public:
+	StaminaSystem() = default;
+
+	void lateUpdate(float deltaTime) override;
+	const char* getName() const override { return "StaminaSystem"; }
+	bool needsLateUpdate() const override { return true; }
+	bool needsUpdate() const override { return false; }
+};
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+inline void StaminaSystem::lateUpdate(float deltaTime) {
+	auto view = m_registry->view<
+		Components::Stamina,
+		Components::CharacterController,
+		Components::CombatController,
+		Components::Health
+	>();
+
+	view.each([&](Components::Stamina& stamina,
+				  Components::CharacterController& controller,
+				  Components::CombatController& combat,
+				  Components::Health& health) {
+
+		// 1. Dead players don't regen
+		if (!health.isAlive()) return;
+
+		// 2. Detect full depletion → enter exhaustion
+		if (stamina.current <= 0.0f && !stamina.exhausted) {
+			stamina.exhausted = true;
+			stamina.drainDelayTimer = stamina.drainDelay;
+		}
+
+		// 3. Tick drain delay during exhaustion
+		if (stamina.exhausted) {
+			stamina.drainDelayTimer -= deltaTime;
+			if (stamina.drainDelayTimer <= 0.0f) {
+				stamina.exhausted = false;
+				stamina.drainDelayTimer = 0.0f;
+			} else {
+				return;  // no regen during drain delay
+			}
+		}
+
+		// 4. No regen while actively spending stamina
+		if (controller.isSprinting) return;
+		if (combat.isAttacking) return;
+		if (combat.isAbility1Casting()) return;
+		if (combat.isAbility2Casting()) return;
+
+		// 5. Scaled regen with 10% minimum floor
+		float ratio = stamina.current / stamina.maximum;
+		float effectiveRate = stamina.baseRegenRate * ratio;
+		effectiveRate = std::max(effectiveRate, stamina.baseRegenRate * 0.10f);
+
+		stamina.current = std::min(stamina.current + effectiveRate * deltaTime, stamina.maximum);
+	});
+}
+
+} // namespace ArenaGame


### PR DESCRIPTION
Add stamina system with sprint/combat gating and HUD bar

Adds a full stamina ECS system to the C++ game engine — stamina component, regen
with scaled recovery, exhaustion threshold, and per-character presets (Knight wired
up)

Gates sprinting and jumping behind stamina cost checks; attacks and skills deduct
stamina with insufficient-stamina blocking
Pipes stamina/max_stamina through the C++ snapshot → CXX bridge → Rust FFI →
frontend types → Babylon.js HUD, rendering an amber stamina bar below the health
bar
Changes

Game engine (C++)

Stamina component with current/max, regen rate, exhaustion flag, and cost config
StaminaSystem ticked each frame — handles regen, drain, and exhaustion state
CombatSystem checks stamina before attacks/skills and deducts on use
CharacterControllerSystem drains stamina on sprint/jump, blocks when exhausted
StaminaPreset added to CharacterPreset; Knight preset populated
Backend (Rust)

stamina and max_stamina fields added to the FFI bridge struct and Rust wrapper
Frontend (TypeScript)

CharacterSnapshot type extended with stamina fields
HUD.ts renders a stamina bar (160×9px, amber fill) below the health bar
SnapshotProcessor.ts updates stamina bar each frame
Test plan

Start a game as Knight — stamina bar appears below health bar, full amber
Hold sprint — stamina drains visibly; release — it regens
Drain stamina fully — sprinting and jumping are blocked until recovery passes
exhaustion threshold
Attack/use abilities — stamina deducts per swing; attacks blocked when stamina
insufficient
Verify enemy players don't show a stamina bar (stamina is local-only HUD)