### PR TITLE
Feat/chrome dev alt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,58 @@ chrome-dev:
 			"http://localhost:8025" >/dev/null 2>&1 & \
 	fi
 
+chrome-dev-alt:
+	@echo "🌐 Launching Chrome dev instance via spki flag (WebTransport enabled)..."; \
+	SPKI_FLAG=""; \
+	SPKI=$$(openssl x509 -in backend/certs/cert.pem -noout -pubkey 2>/dev/null \
+		| openssl pkey -pubin -outform der 2>/dev/null \
+		| openssl dgst -sha256 -binary 2>/dev/null \
+		| base64); \
+	SPKI_FLAG="--ignore-certificate-errors-spki-list=$$SPKI"; \
+	if [ "$$(uname)" = "Darwin" ]; then \
+		if ! open -Ra "Google Chrome" >/dev/null 2>&1; then \
+			echo "⚠️  Google Chrome not found. Install it and try again."; \
+			exit 1; \
+		fi; \
+		open -na "Google Chrome" --args \
+			--user-data-dir="/tmp/chrome-dev-wt" \
+			--webtransport-developer-mode \
+			--no-first-run \
+			--no-default-browser-check \
+			--disable-default-apps \
+			--disable-popup-blocking \
+			--disable-translate \
+			--disable-sync \
+			--password-store=basic \
+			$$SPKI_FLAG \
+			"$(CHROME_URL)" \
+			"http://localhost:8025" >/dev/null 2>&1 & \
+	else \
+		CHROME_BIN=""; \
+		for bin in google-chrome google-chrome-stable chromium chromium-browser; do \
+			if command -v $$bin >/dev/null 2>&1; then \
+				CHROME_BIN=$$bin; break; \
+			fi; \
+		done; \
+		if [ -z "$$CHROME_BIN" ]; then \
+			echo "⚠️  No Chrome/Chromium binary found in PATH."; \
+			exit 1; \
+		fi; \
+		$$CHROME_BIN \
+			--user-data-dir="/tmp/chrome-dev-wt" \
+			--webtransport-developer-mode \
+			$$SPKI_FLAG \
+			--no-first-run \
+			--no-default-browser-check \
+			--disable-default-apps \
+			--disable-popup-blocking \
+			--disable-translate \
+			--disable-sync \
+			--password-store=basic \
+			"$(CHROME_URL)" \
+			"http://localhost:8025" >/dev/null 2>&1 & \
+	fi
+
 # ── Database management ───────────────────────────────────────
 
 reset-db:

--- a/game-core/src/GameMode.hpp
+++ b/game-core/src/GameMode.hpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <random>
 
 namespace ArenaGame {
 
@@ -24,21 +25,24 @@ namespace ArenaGame {
 // =============================================================================
 
 struct SpawnPositions {
+	static constexpr size_t NUM_SPOTS = 5;
+	static constexpr float SPOTS[NUM_SPOTS][2] = {
+		{  12.0f,  -3.0f },
+		{  -4.0f,  -3.0f },
+		{ -12.0f,  11.0f },
+		{  -4.0f,  18.0f },
+		{   7.7f,  18.7f },
+	};
+
 	std::vector<Vector3D> positions;
 	size_t nextIndex = 0;
+	std::mt19937 rng{std::random_device{}()};
 
-	void initialize(int numPlayers) {
-		const float radius = GameConfig::ARENA_WIDTH * 0.35f;
-		const float angleStep = 2.0f * 3.14159265359f / static_cast<float>(numPlayers);
+	void initialize([[maybe_unused]] int numPlayers) {
 		positions.clear();
-		positions.reserve(static_cast<size_t>(numPlayers));
-		for (int i = 0; i < numPlayers; ++i) {
-			float angle = static_cast<float>(i) * angleStep;
-			positions.push_back(Vector3D(
-				radius * std::cos(angle),
-				GameConfig::GROUND_Y,
-				radius * std::sin(angle)
-			));
+		positions.reserve(NUM_SPOTS);
+		for (size_t i = 0; i < NUM_SPOTS; ++i) {
+			positions.push_back(Vector3D(SPOTS[i][0], GameConfig::GROUND_Y, SPOTS[i][1]));
 		}
 		nextIndex = 0;
 	}
@@ -48,6 +52,12 @@ struct SpawnPositions {
 		Vector3D pos = positions[nextIndex];
 		nextIndex = (nextIndex + 1) % positions.size();
 		return pos;
+	}
+
+	Vector3D random() {
+		if (positions.empty()) return Vector3D(0.0f, GameConfig::GROUND_Y, 0.0f);
+		std::uniform_int_distribution<size_t> dist(0, positions.size() - 1);
+		return positions[dist(rng)];
 	}
 };
 
@@ -236,7 +246,7 @@ public:
 		// Respawn players whose timer expired
 		std::erase_if(m_respawnQueue, [&](const RespawnTimer& t) {
 			if (t.remaining > 0.0f) return false;
-			ctx.spawner.respawnPlayer(t.entity, m_spawns.next());
+			ctx.spawner.respawnPlayer(t.entity, m_spawns.random());
 			return true;
 		});
 	}


### PR DESCRIPTION
 Summary                                                                              
  
  - Replace circle-based spawn placement with 5 fixed safe coordinates that don't      
  overlap map objects (fountain, windmill, redhouse, farm, etc.)
  - Deathmatch respawn now picks a random spawn point instead of cycling sequentially
                                                                                       
  Context
                                                                                       
  The upcoming map collider system (feat/map-colliders) adds collision volumes for     
  static objects. The old spawn logic placed players on a circle of radius 17.5 from
  center, which overlaps several large objects like the windmill and redhouse. These   
  positions were manually verified against the collider data in map_colliders.json.

  Spawn coordinates

  ┌─────┬───────┬──────┐                                                               
  │  #  │   X   │  Z   │
  ├─────┼───────┼──────┤                                                               
  │ 1   │ 12.0  │ -3.0 │                                    
  ├─────┼───────┼──────┤
  │ 2   │ -4.0  │ -3.0 │
  ├─────┼───────┼──────┤
  │ 3   │ -12.0 │ 11.0 │
  ├─────┼───────┼──────┤
  │ 4   │ -4.0  │ 18.0 │
  ├─────┼───────┼──────┤                                                               
  │ 5   │ 7.7   │ 18.7 │
  └─────┴───────┴──────┘                                                               
                                                            
  Test plan

  - Verify players spawn at the expected positions in both LastStanding and Deathmatch 
  - Verify Deathmatch respawn places players at random safe spots
  - After merging feat/map-colliders, confirm no player spawns inside a collider       
