### PR TITLE
fix(game-core): prevent stamina drain while sprinting in place

### DIFF
--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -73,8 +73,8 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		return;
 	}
 
-	// Sprint gating: require stamina and not exhausted.
-	if (controller.input.isSprinting && !stamina.isExhausted()) {
+	// Sprint gating: require movement input, stamina, and not exhausted.
+	if (controller.input.isSprinting && controller.hasMovementInput() && !stamina.isExhausted()) {
 		float frameCost = stamina.sprintCostPerSec * deltaTime;
 		if (stamina.canAfford(frameCost)) {
 			stamina.consume(frameCost);


### PR DESCRIPTION
The sprint gate only checked isSprinting (shift held) and stamina state, but not whether the player was actually moving. This caused stamina to deplete continuously when holding shift while standing still.

Add hasMovementInput() check so stamina is only consumed when the player is both sprinting and providing directional input.