### PR TITLE
fix(game-core): freeze dead player physics to prevent post-death drift

### DIFF
--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -68,8 +68,15 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	Components::Stamina& stamina,
 	float deltaTime
 ) {
-	// Skip if movement is disabled or dead
-	if (!controller.canMove || controller.isDead()) {
+	// Dead players must not move — zero velocity and bail out
+	if (controller.isDead()) {
+		physics.velocity.x = 0.0f;
+		physics.velocity.z = 0.0f;
+		return;
+	}
+
+	// Skip if movement is disabled (stunned, casting, etc.)
+	if (!controller.canMove) {
 		return;
 	}
 
@@ -174,9 +181,8 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		}
 	}
 
-	// Handle stunned/dead states (set by combat system)
-	if (controller.isStunned() || controller.isDead()) {
-		// Disable movement when stunned or dead
+	// Handle stunned state (set by combat system)
+	if (controller.isStunned()) {
 		physics.velocity.x = 0.0f;
 		physics.velocity.z = 0.0f;
 	}

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -367,6 +367,10 @@ inline void CombatSystem::processDamage() {
 				controller->setState(CharacterState::Dead);
 				controller->canMove = false;
 			}
+			if (auto* physics = m_registry->try_get<Components::PhysicsBody>(hit.victim)) {
+				physics->velocity.x = 0.0f;
+				physics->velocity.z = 0.0f;
+			}
 		}
 	}
 }

--- a/game-core/src/systems/PhysicsSystem.hpp
+++ b/game-core/src/systems/PhysicsSystem.hpp
@@ -4,6 +4,7 @@
 #include "../components/Transform.hpp"
 #include "../components/PhysicsBody.hpp"
 #include "../components/Collider.hpp"
+#include "../components/Health.hpp"
 #include "../GameTypes.hpp"
 #include "../../entt/entt.hpp"
 
@@ -63,7 +64,18 @@ private:
 inline void PhysicsSystem::fixedUpdate(float fixedDeltaTime) {
 	auto view = m_registry->view<Components::Transform, Components::PhysicsBody, Components::Collider>();
 
-	view.each([&](Components::Transform& transform, Components::PhysicsBody& physics, Components::Collider& collider) {
+	view.each([&](entt::entity entity, Components::Transform& transform, Components::PhysicsBody& physics, Components::Collider& collider) {
+		// Dead entities: gravity + vertical fall only (no horizontal drift)
+		if (auto* health = m_registry->try_get<Components::Health>(entity); health && !health->isAlive()) {
+			physics.velocity.x = 0.0f;
+			physics.velocity.z = 0.0f;
+			applyGravity(physics, fixedDeltaTime);
+			integrateVelocity(transform, physics, fixedDeltaTime);
+			enforceArenaBounds(transform, collider);
+			checkGroundCollision(transform, physics);
+			return;
+		}
+
 		applyGravity(physics, fixedDeltaTime);
 		integrateVelocity(transform, physics, fixedDeltaTime);
 		enforceArenaBounds(transform, collider);


### PR DESCRIPTION
Dead players retained horizontal velocity and kept moving through the map because:

1. CharacterControllerSystem early-returned on isDead() at line 72, making the velocity-zeroing code at line 178 unreachable.
2. CombatSystem set the Dead state but never touched PhysicsBody velocity, so residual movement persisted.
3. PhysicsSystem kept integrating velocity for dead entities while CollisionSystem skipped them — no collision + leftover velocity caused the mesh to fly through walls.

Fix: zero horizontal velocity immediately on death in CombatSystem, enforce it each frame in CharacterControllerSystem and PhysicsSystem. Gravity and vertical integration still run so mid-air kills fall to the ground naturally.