### PR TITLE
fix(game-core): end match when players disconnect mid-game

### DIFF
--- a/game-core/src/GameMode.hpp
+++ b/game-core/src/GameMode.hpp
@@ -100,6 +100,10 @@ public:
 	// Returns true once the mode has determined a winner or loss condition.
 	virtual bool isOver() const = 0;
 
+	// Minimum players required to keep the match running.
+	// Match ends when the player count drops below this.
+	virtual size_t minPlayers() const { return 2; }
+
 	static std::unique_ptr<IGameMode> create(GameModeType type);
 };
 
@@ -274,6 +278,7 @@ public:
 	void tick(float, GameModeContext&,
 			  Components::GameModeComponent&, Components::MatchStatsComponent&) override {}
 	bool isOver() const override { return false; }
+	size_t minPlayers() const override { return 1; }
 };
 
 // =============================================================================

--- a/game-core/src/systems/GameModeSystem.hpp
+++ b/game-core/src/systems/GameModeSystem.hpp
@@ -58,6 +58,9 @@ namespace ArenaGame {
 		void setSpawner(ISpawner* spawner) { m_spawner = spawner; }
 
 	private:
+		void endMatch(Components::GameModeComponent& gm,
+					  const Components::MatchStatsComponent& stats);
+
 		std::unique_ptr<IGameMode> m_mode;
 		ISpawner* m_spawner = nullptr;
 	};
@@ -91,12 +94,30 @@ namespace ArenaGame {
 		m_mode->tick(deltaTime, ctx, *gm, *stats);
 
 		if (m_mode->isOver()) {
-			gm->matchStatus = MatchStatus::Over;
-			auto* ne = m_registry->try_get<Components::NetworkEventsComponent>(m_gameManager);
-			if (ne) ne->events.push_back(buildMatchEndEvent(*m_registry, *stats));
+			endMatch(*gm, *stats);
+		} else {
+			// End the match when too few human players remain (e.g. disconnect).
+			size_t playerCount = 0;
+			for ([[maybe_unused]] auto _ : m_registry->view<PlayerTag>()) ++playerCount;
+
+			if (playerCount < m_mode->minPlayers()) {
+				for (auto entity : m_registry->view<PlayerTag>()) {
+					stats->playerStats[entity].placement = 1;
+				}
+				endMatch(*gm, *stats);
+			}
 		}
 
 		ie->events.clear();
+	}
+
+	inline void GameModeSystem::endMatch(
+		Components::GameModeComponent& gm,
+		const Components::MatchStatsComponent& stats)
+	{
+		gm.matchStatus = MatchStatus::Over;
+		auto* ne = m_registry->try_get<Components::NetworkEventsComponent>(m_gameManager);
+		if (ne) ne->events.push_back(buildMatchEndEvent(*m_registry, stats));
 	}
 
 } // namespace ArenaGame


### PR DESCRIPTION
When a player left during an active game, World::removePlayer() destroyed their entity silently — no event was emitted, so the game mode system was never notified. The match kept running with insufficient players and the frontend never received the MatchEnd message to show the end-game modal.

GameModeSystem::lateUpdate() now checks the remaining player count each tick against the mode's minPlayers() threshold. When too few remain, it awards surviving players first place and pushes a MatchEnd event through the normal path — same tick, same broadcast, frontend gets the modal.

Added IGameMode::minPlayers() virtual (default 2) so each mode controls its own threshold. WaveSurvival overrides to 1 for solo play.

Extracted endMatch() helper to deduplicate the matchStatus + MatchEnd event push that was repeated in both the normal and disconnect paths.