### PR TITLE
fix(game/crashsite) div by 0, unchecked vector, empty chain

### DIFF
--- a/game-core/src/ArenaGame.hpp
+++ b/game-core/src/ArenaGame.hpp
@@ -252,9 +252,12 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 		charSnapshot.ability1Cooldown = combat.ability1.cooldown;
 		charSnapshot.ability2Timer    = combat.skill2CooldownTimer;
 		charSnapshot.ability2Cooldown = combat.ability2.cooldown;
-		charSnapshot.swingProgress    = (combat.isAttacking && !combat.attackChain.empty())
-			? combat.swingTimer / combat.currentStage().duration
-			: 0.0f;
+		{
+			float duration = combat.currentStage().duration;
+			charSnapshot.swingProgress = (combat.isAttacking && duration > 0.0f)
+				? combat.swingTimer / duration
+				: 0.0f;
+		}
 		charSnapshot.isGrounded       = physics.isGrounded;
 		charSnapshot.stamina    = stam.current;
 		charSnapshot.maxStamina = stam.maximum;

--- a/game-core/src/components/CombatController.hpp
+++ b/game-core/src/components/CombatController.hpp
@@ -83,8 +83,15 @@ struct CombatController {
 	// ── Queries ──────────────────────────────────────────────────────────────
 
 	// Returns the stage that fires on the next attack input.
+	// Bounds-safe: clamps chainStage to valid range; returns a static
+	// default if the chain is empty (prevents out-of-bounds access).
 	const AttackStage& currentStage() const {
-		return attackChain[static_cast<size_t>(chainStage)];
+		if (attackChain.empty()) {
+			static const AttackStage fallback{};
+			return fallback;
+		}
+		size_t idx = static_cast<size_t>(std::max(0, chainStage));
+		return attackChain[std::min(idx, attackChain.size() - 1)];
 	}
 
 	bool isAbility1Casting() const { return skill1CastTimer > 0.0f; }

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -240,9 +240,10 @@ inline void CombatSystem::processInputAttacks() {
 		CombatController::BufferedAction toFire = comcon.bufferedAction;
 		comcon.bufferedAction = CombatController::BufferedAction::None;
 
-		// Discard buffered action if stamina is insufficient
+		// Discard buffered attack if chain is empty or stamina is insufficient
 		if (toFire == CombatController::BufferedAction::Attack
-				&& !stamina.canAfford(comcon.currentStage().staminaCost))
+				&& (comcon.attackChain.empty()
+					|| !stamina.canAfford(comcon.currentStage().staminaCost)))
 			toFire = CombatController::BufferedAction::None;
 		if (toFire == CombatController::BufferedAction::Skill1
 				&& !stamina.canAfford(comcon.ability1.staminaCost))


### PR DESCRIPTION
hot path - currentStage() is called every frame by updateTimers, every frame by createSnapshot, and on every buffered attack input. Any one of these could produce a SIGSEGV under the right (unlucky) conditions.

1. currentStage() is now bounds-safe — before, attackChain[chainStage] was an
  unchecked vector access. If chainStage ever went out of sync
(corruption, race,
  empty chain), it was instant UB — either reading garbage memory or
SIGSEGV. Now
  it clamps to valid range and returns a static fallback for empty
chains.
  2. createSnapshot no longer divides by zero — duration is checked before
  division. Previously, a zero-duration stage would produce inf, which
flowed
  through CXX to Rust's serde serialization on every tick at 60Hz. Now
it safely
  returns 0.0f.
  3. Buffered attack input now checks for empty chain — the buffered action path
  in CombatSystem bypassed the canPerformAttack() guard (which checks
  !attackChain.empty()). A buffered attack on an entity with an empty
chain would
  call the old unchecked currentStage(). Now the buffer is discarded if
the chain
  is empty, matching the live input path.