### PR TITLE
fix(game) prevent crashes from stale entity refs on disconnect

### DIFF
--- a/game-core/src/GameMode.hpp
+++ b/game-core/src/GameMode.hpp
@@ -97,6 +97,11 @@ public:
 					  Components::GameModeComponent& gm,
 					  Components::MatchStatsComponent& stats) = 0;
 
+	// Called when a player entity is about to be destroyed (disconnect / removal).
+	// Override to purge any maps or queues that hold this entity.
+	virtual void onPlayerRemove([[maybe_unused]] entt::entity entity,
+								[[maybe_unused]] Components::MatchStatsComponent& stats) {}
+
 	// Returns true once the mode has determined a winner or loss condition.
 	virtual bool isOver() const = 0;
 
@@ -156,6 +161,11 @@ public:
 			});
 			m_over = true;
 		}
+	}
+
+	void onPlayerRemove(entt::entity entity,
+					    Components::MatchStatsComponent& stats) override {
+		stats.playerStats.erase(entity);
 	}
 
 	void tick([[maybe_unused]] float dt,
@@ -236,6 +246,15 @@ public:
 
 		for (int i = 0; i < static_cast<int>(ranked.size()); i++)
 			stats.playerStats[ranked[static_cast<size_t>(i)].first].placement = i + 1;
+	}
+
+	void onPlayerRemove(entt::entity entity,
+					    Components::MatchStatsComponent& stats) override {
+		std::erase_if(m_respawnQueue, [entity](const RespawnTimer& t) {
+			return t.entity == entity;
+		});
+		m_killCounts.erase(entity);
+		stats.playerStats.erase(entity);
 	}
 
 	void tick(float dt,

--- a/game-core/src/core/World.hpp
+++ b/game-core/src/core/World.hpp
@@ -352,6 +352,9 @@ inline bool World::removePlayer(PlayerID id) {
 		return false;
 	}
 
+	// Notify game mode before destruction so it can purge stale entity refs
+	if (m_gameModeSystem) m_gameModeSystem->notifyPlayerRemove(entity);
+
 	// Unregister PlayerID mapping
 	unregisterPlayerIDMapping(entity);
 
@@ -361,7 +364,7 @@ inline bool World::removePlayer(PlayerID id) {
 }
 inline void World::respawnPlayer(entt::entity player, const Vector3D& pos) {
 	auto* health = m_registry.try_get<Components::Health>(player);
-	if (!health->isDead) return;
+	if (!health || !health->isDead) return;
 	auto* physicsBody = m_registry.try_get<Components::PhysicsBody>(player);
 	auto* transform   = m_registry.try_get<Components::Transform>(player);
 

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -22,6 +22,7 @@
 #include <queue>
 #include <variant>
 #include <cstdlib>
+#include <random>
 
 namespace ArenaGame {
 
@@ -59,7 +60,9 @@ namespace ArenaGame {
 // stageMultiplier comes from AttackStage::damageMultiplier or SkillDefinition::dmgMultiplier.
 inline float calculateCombatDamage(const Components::CombatController& cc, float stageMultiplier) {
 	float dmg = cc.baseDamage * stageMultiplier * cc.damageMultiplier;
-	bool isCrit = (static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX)) < cc.criticalChance;
+	thread_local std::mt19937 rng{std::random_device{}()};
+	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+	bool isCrit = dist(rng) < cc.criticalChance;
 	return isCrit ? dmg * cc.criticalMultiplier : dmg;
 }
 

--- a/game-core/src/systems/GameModeSystem.hpp
+++ b/game-core/src/systems/GameModeSystem.hpp
@@ -57,6 +57,13 @@ namespace ArenaGame {
 
 		void setSpawner(ISpawner* spawner) { m_spawner = spawner; }
 
+		void notifyPlayerRemove(entt::entity entity) {
+			if (!m_mode) return;
+			auto* stats = m_registry->try_get<Components::MatchStatsComponent>(m_gameManager);
+			if (!stats) return;
+			m_mode->onPlayerRemove(entity, *stats);
+		}
+
 	private:
 		void endMatch(Components::GameModeComponent& gm,
 					  const Components::MatchStatsComponent& stats);


### PR DESCRIPTION
Bug A: Guaranteed SIGSEGV in Deathmatch respawn                                                      
                                                                                                       
  World::respawnPlayer calls try_get<Health>(player) which returns nullptr for a destroyed entity, then
   immediately dereferences it without a null check. The Deathmatch respawn queue stores raw
  entt::entity handles with a 5-second delay. If a player disconnects while queued for respawn, the    
  entity is destroyed but the queue still fires — calling respawnPlayer with a dead handle → null
  dereference → process killed.

  Fix: Added null guard in respawnPlayer (if (!health || !health->isDead) return). Added onPlayerRemove
   virtual hook to IGameMode — Deathmatch overrides it to erase the disconnected entity from
  m_respawnQueue so the respawn never fires.                                                           
                  
  Bug B: Stale entity keys in game mode maps                                                           
   
  When a player disconnects, World::removePlayer destroys the entity but never notifies the game mode. 
  Three maps retain the stale entity handle: MatchStatsComponent::playerStats,
  Deathmatch::m_killCounts, and Deathmatch::m_respawnQueue. With ~5-15 entities per match, entt        
  recycles entity indices quickly — subsequent lookups on these maps could return data for the wrong
  player.

  Fix: World::removePlayer now calls GameModeSystem::notifyPlayerRemove(entity) before destroying the  
  entity. Deathmatch purges all three maps; LastStanding purges playerStats. All stale references are
  cleaned up before the entity is destroyed.                                                           
                  
  Bug C: std::rand() is not thread-safe

  CombatSystem.hpp uses std::rand() for crit chance calculations. The game loop runs on a std::thread  
  while the Tokio runtime may call libc rand() from other threads, corrupting its shared internal
  state. This can produce garbage crit values.                                                         
                  
  Fix: Replaced std::rand() with a thread_local std::mt19937 using std::uniform_real_distribution —    
  same pattern already used in GameMode.hpp for spawn positions. Each thread gets its own RNG instance,
   no shared state.                                                                                    
                  
  Test plan

  - Start a Deathmatch game, kill a player, disconnect the victim during the 5s respawn timer — server 
  should not crash
  - Disconnect a player mid-match in both LastStanding and Deathmatch — match should continue normally 
  for remaining players
  - Verify match-end stats only contain connected players
  - Verify crit damage still applies correctly in combat