### PR TITLE
fix(game) discard buffered attack when attack chain is empty

### DIFF
--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -240,9 +240,10 @@ inline void CombatSystem::processInputAttacks() {
 		CombatController::BufferedAction toFire = comcon.bufferedAction;
 		comcon.bufferedAction = CombatController::BufferedAction::None;
 
-		// Discard buffered action if stamina is insufficient
+		// Discard buffered attack if chain is empty or stamina is insufficient
 		if (toFire == CombatController::BufferedAction::Attack
-				&& !stamina.canAfford(comcon.currentStage().staminaCost))
+				&& (comcon.attackChain.empty()
+					|| !stamina.canAfford(comcon.currentStage().staminaCost)))
 			toFire = CombatController::BufferedAction::None;
 		if (toFire == CombatController::BufferedAction::Skill1
 				&& !stamina.canAfford(comcon.ability1.staminaCost))


### PR DESCRIPTION
 Summary                                                                                              

  - The buffered action path in CombatSystem::processInputAttacks called currentStage().staminaCost    
  without checking attackChain.empty() first. The live input path goes through canPerformAttack() which
   guards against empty chains, but the buffered path bypassed that — causing an out-of-bounds vector  
  read for entities with no attack chain (e.g. createDefault()).
  - Fix: discard the buffered attack if the chain is empty, matching the live input path behavior.
                                                                                                       
  Test plan                                                                                            
                                                                                                       
  - Verify normal attack combos still chain correctly for all character classes                        
  - Verify buffered attacks during ability casts still fire after the cast ends