### PR TITLE
add(be/signal-handler) to guard against crashes

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5201,6 +5201,7 @@ dependencies = [
  "indexmap",
  "jsonwebtoken",
  "lettre",
+ "libc",
  "mini-moka",
  "parking_lot",
  "pingora-limits",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -192,6 +192,8 @@ lettre = { version = "0.11", default-features = false, features = [
 rustls = { version = "0.23", default-features = false, features = [
 	"aws_lc_rs",
 ] }
+# signal handler for SIGSEGV crash diagnostics
+libc = "0.2"
 
 [features]
 # Enable these features to run the test suite with mock users that have 2FA
@@ -220,7 +222,8 @@ cxx-build = "1.0"
 opt-level = 3
 lto = "thin"      # cross-language LTO with Clang — inlines across Rust/C++ boundary
 codegen-units = 1 # single CGU; not implied by thin LTO, must be set explicitly
-strip = "symbols" # smaller binary; requires Rust 1.77+
+strip = false     # keep symbols for SIGSEGV backtrace diagnostics (was "symbols")
+debug  = 1        # line-tables-only — enables readable backtraces with ~10 MB cost
 
 [profile.dev.package.argon2]
 opt-level = 3

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -39,6 +39,10 @@ use crate::{db::Database as _, email::Mailer};
 pub static ON_SHUTDOWN: Notify = Notify::const_new();
 
 fn main() -> std::process::ExitCode {
+    // Install SIGSEGV/SIGABRT/SIGBUS handler FIRST — before any threads are
+    // spawned — so that C++ segfaults print a backtrace instead of dying silently.
+    crate::utils::crash_handler::install();
+
     use std::sync::atomic::{AtomicUsize, Ordering};
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()

--- a/backend/src/utils/crash_handler.rs
+++ b/backend/src/utils/crash_handler.rs
@@ -63,8 +63,7 @@ extern "C" fn handler(sig: libc::c_int, _info: *mut libc::siginfo_t, _ctx: *mut 
 #[cfg(unix)]
 fn write_backtrace() {
     type BacktraceFn = unsafe extern "C" fn(*mut *mut libc::c_void, libc::c_int) -> libc::c_int;
-    type SymbolsFdFn =
-        unsafe extern "C" fn(*const *mut libc::c_void, libc::c_int, libc::c_int);
+    type SymbolsFdFn = unsafe extern "C" fn(*const *mut libc::c_void, libc::c_int, libc::c_int);
 
     // Try to resolve the glibc backtrace functions at runtime.
     let (bt, bt_fd) = unsafe {

--- a/backend/src/utils/crash_handler.rs
+++ b/backend/src/utils/crash_handler.rs
@@ -1,0 +1,96 @@
+/// Installs signal handlers for SIGSEGV, SIGABRT, and SIGBUS that print a
+/// backtrace to stderr before re-raising the signal for the default action.
+///
+/// This is specifically designed to diagnose crashes originating in the C++
+/// game engine (via CXX FFI), which produce signals that bypass Rust's
+/// `catch_unwind`.
+///
+/// Must be called once, early in `main()`, before spawning any threads.
+/// The handler uses `backtrace` / `backtrace_symbols_fd` from glibc, which
+/// are async-signal-safe on Linux.  On non-glibc systems the handler still
+/// prints the signal name but skips the backtrace.
+#[cfg(unix)]
+pub fn install() {
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = handler as usize;
+        sa.sa_flags = libc::SA_SIGINFO;
+        libc::sigemptyset(&mut sa.sa_mask);
+
+        libc::sigaction(libc::SIGSEGV, &sa, std::ptr::null_mut());
+        libc::sigaction(libc::SIGABRT, &sa, std::ptr::null_mut());
+        libc::sigaction(libc::SIGBUS, &sa, std::ptr::null_mut());
+    }
+}
+
+#[cfg(not(unix))]
+pub fn install() {}
+
+// ── Signal handler (async-signal-safe only) ──────────────────────────────────
+
+#[cfg(unix)]
+extern "C" fn handler(sig: libc::c_int, _info: *mut libc::siginfo_t, _ctx: *mut libc::c_void) {
+    let label: &[u8] = match sig {
+        libc::SIGSEGV => b"\n=== CRASH: SIGSEGV (segmentation fault) ===\n",
+        libc::SIGABRT => b"\n=== CRASH: SIGABRT (abort) ===\n",
+        libc::SIGBUS => b"\n=== CRASH: SIGBUS (bus error) ===\n",
+        _ => b"\n=== CRASH: unknown fatal signal ===\n",
+    };
+
+    unsafe {
+        libc::write(libc::STDERR_FILENO, label.as_ptr().cast(), label.len());
+    }
+
+    write_backtrace();
+
+    unsafe {
+        let footer = b"=== Re-raising signal for default handler (core dump) ===\n\n";
+        libc::write(libc::STDERR_FILENO, footer.as_ptr().cast(), footer.len());
+
+        // Restore default handler and re-raise so the OS generates a core dump
+        // and the exit code still reflects the signal.
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}
+
+// ── Backtrace capture ────────────────────────────────────────────────────────
+//
+// glibc exposes `backtrace` and `backtrace_symbols_fd` which are
+// async-signal-safe.  We link them dynamically so the build still succeeds
+// on musl (where they are absent) — we just skip the backtrace.
+
+#[cfg(unix)]
+fn write_backtrace() {
+    type BacktraceFn = unsafe extern "C" fn(*mut *mut libc::c_void, libc::c_int) -> libc::c_int;
+    type SymbolsFdFn =
+        unsafe extern "C" fn(*const *mut libc::c_void, libc::c_int, libc::c_int);
+
+    // Try to resolve the glibc backtrace functions at runtime.
+    let (bt, bt_fd) = unsafe {
+        (
+            libc::dlsym(libc::RTLD_DEFAULT, b"backtrace\0".as_ptr().cast()),
+            libc::dlsym(
+                libc::RTLD_DEFAULT,
+                b"backtrace_symbols_fd\0".as_ptr().cast(),
+            ),
+        )
+    };
+
+    if bt.is_null() || bt_fd.is_null() {
+        unsafe {
+            let msg = b"(backtrace unavailable on this libc)\n";
+            libc::write(libc::STDERR_FILENO, msg.as_ptr().cast(), msg.len());
+        }
+        return;
+    }
+
+    let backtrace_fn: BacktraceFn = unsafe { std::mem::transmute(bt) };
+    let symbols_fd_fn: SymbolsFdFn = unsafe { std::mem::transmute(bt_fd) };
+
+    let mut buf: [*mut libc::c_void; 128] = [std::ptr::null_mut(); 128];
+    let depth = unsafe { backtrace_fn(buf.as_mut_ptr(), 128) };
+    if depth > 0 {
+        unsafe { symbols_fd_fn(buf.as_ptr(), depth, libc::STDERR_FILENO) };
+    }
+}

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 pub mod adaptive_buffer;
+pub mod crash_handler;
 pub mod limiter;
 pub mod logger;
 #[allow(dead_code)]


### PR DESCRIPTION
backend/Cargo.toml — 3 changes:
  - Added libc = "0.2" dependency for signal handling
  - Changed strip = "symbols" → strip = false so the backtrace has function names
  - Added debug = 1 (line-tables-only) for file/line info in backtraces (~10MB
  binary size increase)

  backend/src/utils/crash_handler.rs — New file:
  - Installs signal handlers for SIGSEGV, SIGABRT, and SIGBUS
  - On crash: prints the signal name, captures a full backtrace via glibc's
  backtrace_symbols_fd, then re-raises the signal
  - Uses dlsym to load backtrace functions at runtime — gracefully degrades on
  musl (prints "backtrace unavailable")

  backend/src/main.rs — Added crash_handler::install() as the first call in main()

  backend/src/utils/mod.rs — Registered the new module

When C++ code segfaults, the OS delivers SIGSEGV
  to the faulting thread. Our handler runs on that same thread — so the
backtrace
  it captures is the exact call stack that crashed. The
backtrace_symbols_fd
  function resolves addresses to symbol names (function names + offsets)
using the
   ELF symbol table. With strip = false and debug = 1, you'll see
readable
  function names like ArenaGame::CollisionSystem::fixedUpdate+0x1a3
instead of
  bare hex addresses.