### PR TITLE
Fix/spectator default model

### DIFF
--- a/backend/src/game/manager.rs
+++ b/backend/src/game/manager.rs
@@ -289,57 +289,77 @@ impl GameManager {
         }
 
         // Phase 3: sync — finalize, send snapshot, collect mid-game data (under lobby lock)
-        {
-            let (game_streams, is_game_active) = {
-                let mut lobby = lobby_arc.lock();
-                lobby.finish_add_spectator(user_id, nickname);
-                let snapshot = lobby.info();
-                lobby
-                    .lobby_streams()
-                    .send(user_id, &LobbyServerMessage::LobbySnapshot(snapshot));
-                (Arc::clone(lobby.game_streams()), lobby.is_game_active())
-            };
+        let mid_game = {
+            let mut lobby = lobby_arc.lock();
+            lobby.finish_add_spectator(user_id, nickname);
+            let snapshot = lobby.info();
+            lobby
+                .lobby_streams()
+                .send(user_id, &LobbyServerMessage::LobbySnapshot(snapshot));
 
             // If a game is already running, open a game stream for this spectator immediately
             // so they can watch. Collect the data we need (under lock) before releasing.
-            if is_game_active {
-                let result = game_streams
-                    .create_stream::<GameClientMessage>(
-                        user_id,
-                        StreamType::Game,
-                        &self.sm,
-                        |_user_id, _msg| true,
-                    )
-                    .await;
+            if lobby.is_game_active() {
+                let players = lobby.player_data().collect::<Vec<_>>();
+                let game_streams = Arc::clone(lobby.game_streams());
+                Some((players, game_streams))
+            } else {
+                None
+            }
+        };
 
-                match result {
-                    Ok(_) => {
-                        // Guard against the race where the game ended between checking is_game_active() and opening the stream —
-                        // and here: clear_game() replaces lobby.game_streams with a
-                        // fresh Arc, so the Arc we hold is now detached. If we kept
-                        // it, StreamGroup::Drop would immediately cancel the handle
-                        // when our local Arc goes out of scope.
-                        let still_active = {
-                            let lobby = lobby_arc.lock();
-                            lobby.is_game_active()
-                                && Arc::ptr_eq(lobby.game_streams(), &game_streams)
-                        };
-                        if !still_active {
-                            // Game ended in the race window; our stream handle is on a
-                            // dead group. Tear it down explicitly before the Arc drops.
-                            game_streams.destroy_handle(user_id);
-                            warn!(lobby_id = %lobby_id, user_id,
-                            "game ended before mid-game spectator stream was established; discarding");
+        // Phase 4: async — open game stream for mid-game spectator (no locks held)
+        if let Some((players, game_streams)) = mid_game {
+            let result = game_streams
+                .create_stream::<GameClientMessage>(
+                    user_id,
+                    StreamType::Game,
+                    &self.sm,
+                    |_user_id, _msg| true,
+                )
+                .await;
+
+            match result {
+                Ok(_) => {
+                    // Guard against the race where the game ended between Phase 3
+                    // and here: clear_game() replaces lobby.game_streams with a
+                    // fresh Arc, so the Arc we hold is now detached. If we kept
+                    // it, StreamGroup::Drop would immediately cancel the handle
+                    // when our local Arc goes out of scope.
+                    let still_active = {
+                        let lobby = lobby_arc.lock();
+                        lobby.is_game_active() && Arc::ptr_eq(lobby.game_streams(), &game_streams)
+                    };
+
+                    if still_active {
+                        // Send PlayerJoined for every current player so the spectator's
+                        // GameContext knows who is in the game.
+                        for (uid, nick, character_class) in &players {
+                            game_streams.send(
+                                user_id,
+                                &GameServerMessage::PlayerJoined {
+                                    player_id: (*uid).cast_unsigned(),
+                                    name: nick.to_string(),
+                                    character_class: *character_class,
+                                },
+                            );
                         }
-                    }
-                    Err(error) => {
-                        warn!(lobby_id = %lobby_id, user_id, %error,
-                        "failed to open mid-game game stream for spectator");
+                    } else {
+                        // Game ended in the race window; our stream handle is on a
+                        // dead group. Tear it down explicitly before the Arc drops.
+                        game_streams.destroy_handle(user_id);
+                        warn!(lobby_id = %lobby_id, user_id,
+                            "game ended before mid-game spectator stream was established; discarding");
                     }
                 }
+                Err(e) => {
+                    warn!(lobby_id = %lobby_id, user_id, error = %e,
+                        "failed to open mid-game game stream for spectator");
+                }
             }
-            debug!(lobby_id = %lobby_id, user_id, "spectator joined lobby");
         }
+
+        debug!(lobby_id = %lobby_id, user_id, "spectator joined lobby");
         Ok(())
     }
 

--- a/backend/src/game/messages.rs
+++ b/backend/src/game/messages.rs
@@ -8,6 +8,13 @@ pub enum GameServerMessage {
     /// Full game state snapshot (sent at 60 Hz)
     Snapshot(GameStateSnapshot),
 
+    /// Player successfully joined the game
+    PlayerJoined {
+        player_id: u32,
+        name: String,
+        character_class: CharacterClass,
+    },
+
     /// Another player left the game
     PlayerLeft { player_id: u32 },
 

--- a/frontend/src/contexts/GameContext.tsx
+++ b/frontend/src/contexts/GameContext.tsx
@@ -240,6 +240,21 @@ export function GameProvider({ children }: { children: ReactNode }) {
 						snapshotRef.current = msg as unknown as GameStateSnapshot;
 						return;
 					}
+					if (msg.type === 'PlayerJoined') {
+						console.debug(
+							'[Game] PlayerJoined player_id=%d name=%s class=%s',
+							msg.player_id,
+							msg.name,
+							msg.character_class,
+						);
+						characterClassesRef.current.set(msg.player_id, msg.character_class);
+						dispatch({
+							type: 'PLAYER_JOINED',
+							player_id: msg.player_id,
+							name: msg.name,
+						});
+						return;
+					}
 					if (msg.type === 'PlayerLeft') {
 						console.debug('[Game] PlayerLeft player_id=%d', msg.player_id);
 						dispatch({ type: 'PLAYER_LEFT', player_id: msg.player_id });

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -49,6 +49,7 @@ export interface PlayerMatchStats {
 // Using discriminated union with 'type' field (matches Rust #[serde(tag = "type")])
 export type GameServerMessage =
 	| ({ type: 'Snapshot' } & GameStateSnapshot)
+	| { type: 'PlayerJoined'; player_id: number; name: string; character_class: string }
 	| { type: 'PlayerLeft'; player_id: number }
 	| { type: 'Death'; killer: number; victim: number }
 	| { type: 'Damage'; attacker: number; victim: number; damage: number }


### PR DESCRIPTION
  - Backend (from the revert): When a spectator joins mid-game, the manager
  iterates all current players and sends a PlayerJoined { player_id, name,
  character_class } for each one.
  - Frontend (the two edits): GameContext handles the PlayerJoined message by
  immediately writing to characterClassesRef and dispatching PLAYER_JOINED to the
  reducer — the same effect as an initial Spawn, but without waiting for the
  player to actually die and respawn.