### PR TITLE
fix(game) include disconnected players in match-end stats

### DIFF
--- a/game-core/src/GameMode.hpp
+++ b/game-core/src/GameMode.hpp
@@ -134,8 +134,12 @@ public:
 
 		for (const auto& p : pp->players) {
 			entt::entity entity = ctx.spawner.createPlayer(p.id, p.name, p.characterClass, m_spawns.next());
-			if (entity != entt::null)
-				stats.playerStats.try_emplace(entity);
+			if (entity != entt::null) {
+				auto& ps = stats.playerStats[entity];
+				ps.playerID       = p.id;
+				ps.name            = p.name;
+				ps.characterClass  = p.characterClass;
+			}
 		}
 	}
 
@@ -161,11 +165,6 @@ public:
 			});
 			m_over = true;
 		}
-	}
-
-	void onPlayerRemove(entt::entity entity,
-					    Components::MatchStatsComponent& stats) override {
-		stats.playerStats.erase(entity);
 	}
 
 	void tick([[maybe_unused]] float dt,
@@ -211,8 +210,12 @@ public:
 
 		for (const auto& p : pp->players) {
 			entt::entity entity = ctx.spawner.createPlayer(p.id, p.name, p.characterClass, m_spawns.next());
-			if (entity != entt::null)
-				stats.playerStats.try_emplace(entity);
+			if (entity != entt::null) {
+				auto& ps = stats.playerStats[entity];
+				ps.playerID       = p.id;
+				ps.name            = p.name;
+				ps.characterClass  = p.characterClass;
+			}
 		}
 	}
 
@@ -249,12 +252,11 @@ public:
 	}
 
 	void onPlayerRemove(entt::entity entity,
-					    Components::MatchStatsComponent& stats) override {
+					    [[maybe_unused]] Components::MatchStatsComponent& stats) override {
 		std::erase_if(m_respawnQueue, [entity](const RespawnTimer& t) {
 			return t.entity == entity;
 		});
 		m_killCounts.erase(entity);
-		stats.playerStats.erase(entity);
 	}
 
 	void tick(float dt,

--- a/game-core/src/components/MatchStatsComponent.hpp
+++ b/game-core/src/components/MatchStatsComponent.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <unordered_map>
+#include <string>
+#include "../GameTypes.hpp"
 #include "../../entt/entt.hpp"
 
 namespace ArenaGame {
@@ -8,6 +10,11 @@ namespace Components {
 	struct MatchStatsComponent {
 
 		struct PlayerStats {
+			// Identity snapshot — captured at match start, survives entity destruction.
+			PlayerID    playerID       = 0;
+			std::string name;
+			std::string characterClass;
+
 			int   kills       = 0;
 			int   deaths      = 0;
 			float damageDealt = 0.0f;

--- a/game-core/src/systems/GameModeSystem.hpp
+++ b/game-core/src/systems/GameModeSystem.hpp
@@ -4,7 +4,6 @@
 #include "../components/MatchStatsComponent.hpp"
 #include "../components/InternalEventsComponent.hpp"
 #include "../components/NetworkEventsComponent.hpp"
-#include "../components/PlayerInfo.hpp"
 #include "../components/Tags.hpp"
 #include "../events/InternalEvents.hpp"
 #include "../events/NetworkEvents.hpp"
@@ -17,24 +16,21 @@
 namespace ArenaGame {
 
 	// Builds the MatchEnd payload from final match stats.
-	// Skips bots (human-facing modal) and entities missing PlayerInfo.
+	// Identity is stored in PlayerStats at match start, so disconnected
+	// players are included even after their entity is destroyed.
 	inline NetEvents::MatchEndEvent buildMatchEndEvent(
-		const entt::registry& registry,
 		const Components::MatchStatsComponent& stats)
 	{
 		NetEvents::MatchEndEvent out;
 		out.players.reserve(stats.playerStats.size());
 
 		for (const auto& [entity, ps] : stats.playerStats) {
-			if (registry.all_of<BotTag>(entity)) continue;
-
-			const auto* info = registry.try_get<Components::PlayerInfo>(entity);
-			if (!info) continue;
+			if (ps.playerID == 0) continue; // skip bots / uninitialized
 
 			out.players.push_back(NetEvents::PlayerMatchStats{
-				info->playerID,
-				info->name,
-				info->characterClass,
+				ps.playerID,
+				ps.name,
+				ps.characterClass,
 				ps.kills,
 				ps.deaths,
 				ps.damageDealt,
@@ -124,7 +120,7 @@ namespace ArenaGame {
 	{
 		gm.matchStatus = MatchStatus::Over;
 		auto* ne = m_registry->try_get<Components::NetworkEventsComponent>(m_gameManager);
-		if (ne) ne->events.push_back(buildMatchEndEvent(*m_registry, stats));
+		if (ne) ne->events.push_back(buildMatchEndEvent(stats));
 	}
 
 } // namespace ArenaGame


### PR DESCRIPTION
c613596 introduced onPlayerRemove to clean up stale entity refs on disconnect, which correctly purges the respawn queue and kill counts. However it also erased the player's entry from MatchStatsComponent, so buildMatchEndEvent never saw them — the leaderboard only showed players still connected at match end.

Fix: store player identity (playerID, name, characterClass) directly in PlayerStats at match start so it survives entity destruction. buildMatchEndEvent now reads identity from the stats entry instead of querying PlayerInfo on the (destroyed) entity. Stop erasing stats entries in onPlayerRemove — only internal game-mode state needs cleanup.