### PR TITLE
feat(game) extend swing trail ribbon to skills

### DIFF
--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -43,7 +43,7 @@ const MAX_SESSIONS_PER_USER: i64 = 10;
 ///
 /// Server-side rules (rolling expiry / forced reauth) still apply; this just
 /// allows reactivation of long-lived sessions at a later time.
-const SESSION_COOKIE_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 10);
+const SESSION_COOKIE_MAX_AGE: Duration = Duration::from_hours(87600);
 
 /// Dont care about old JWT tokens when server restarts,
 /// clients can just refresh their access tokens.

--- a/backend/src/game/ffi.rs
+++ b/backend/src/game/ffi.rs
@@ -36,6 +36,7 @@ mod bridge {
         jumping: bool,
         ability1: bool,
         ability2: bool,
+        ability2_held: bool,
         dodging: bool,
         sprinting: bool,
     }
@@ -181,6 +182,7 @@ impl From<GameMode> for bridge::GameModeType {
 pub enum CharacterClass {
     #[default]
     Knight,
+    Barbarian,
     Rogue,
 }
 
@@ -188,6 +190,7 @@ impl CharacterClass {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Knight => "knight",
+            Self::Barbarian => "barbarian",
             Self::Rogue => "rogue",
         }
     }
@@ -196,6 +199,7 @@ impl CharacterClass {
 impl From<&str> for CharacterClass {
     fn from(s: &str) -> Self {
         match s {
+            "barbarian" => Self::Barbarian,
             "rogue" => Self::Rogue,
             _ => Self::Knight,
         }
@@ -390,6 +394,7 @@ impl GameHandle {
         jumping: bool,
         ability1: bool,
         ability2: bool,
+        ability2_held: bool,
         dodging: bool,
         sprinting: bool,
     ) {
@@ -408,6 +413,7 @@ impl GameHandle {
             jumping,
             ability1,
             ability2,
+            ability2_held,
             dodging,
             sprinting,
         };

--- a/backend/src/game/game.rs
+++ b/backend/src/game/game.rs
@@ -69,6 +69,7 @@ impl Game {
                 jumping,
                 ability1,
                 ability2,
+                ability2_held,
                 dodging,
                 sprinting,
             } => {
@@ -80,6 +81,7 @@ impl Game {
                     jumping,
                     ability1,
                     ability2,
+                    ability2_held,
                     dodging,
                     sprinting,
                 );

--- a/backend/src/game/lobby.rs
+++ b/backend/src/game/lobby.rs
@@ -19,7 +19,7 @@ use super::messages::GameServerMessage;
 use crate::models::nickname::Nickname;
 use crate::stream::StreamGroup;
 
-const COUNTDOWN_DEFAULT: Duration = Duration::from_secs(60);
+const COUNTDOWN_DEFAULT: Duration = Duration::from_mins(1);
 const COUNTDOWN_ALL_READY: Duration = Duration::from_secs(3);
 const COUNTDOWN_FULL: Duration = Duration::from_secs(10);
 const CLEANUP_DELAY: Duration = Duration::from_secs(30);

--- a/backend/src/game/messages.rs
+++ b/backend/src/game/messages.rs
@@ -71,6 +71,8 @@ pub enum GameClientMessage {
         #[serde(default)]
         ability2: bool,
         #[serde(default)]
+        ability2_held: bool,
+        #[serde(default)]
         dodging: bool,
         #[serde(default)]
         sprinting: bool,

--- a/backend/src/stream/stream_manager.rs
+++ b/backend/src/stream/stream_manager.rs
@@ -857,7 +857,7 @@ pub async fn connect_stream(
                             connection_id,
                             "Connection displaced by newer session"
                         );
-                        tokio::time::sleep(Duration::from_millis(1000)).await; // Give the message a moment to be processed by the client
+                        tokio::time::sleep(Duration::from_secs(1)).await; // Give the message a moment to be processed by the client
                         break;
                     }
                 }

--- a/backend/src/utils/limiter.rs
+++ b/backend/src/utils/limiter.rs
@@ -29,7 +29,7 @@ pub fn periodic_rate_limit_report() {
     use tokio::time::interval;
 
     tokio::spawn(async move {
-        let mut interval = interval(Duration::from_secs(60 * 10));
+        let mut interval = interval(Duration::from_mins(10));
         loop {
             interval.tick().await;
             let total = RATE_LIMITED_COUNTERS.iter().fold(0, |out, counter| {
@@ -76,22 +76,22 @@ impl RateLimit {
 
     #[must_use]
     pub fn per_minute(limit: u32) -> Self {
-        Self::new(limit, Duration::from_secs(60))
+        Self::new(limit, Duration::from_mins(1))
     }
 
     #[must_use]
     pub fn per_5_minutes(limit: u32) -> Self {
-        Self::new(limit, Duration::from_secs(300))
+        Self::new(limit, Duration::from_mins(5))
     }
 
     #[must_use]
     pub fn per_15_minutes(limit: u32) -> Self {
-        Self::new(limit, Duration::from_secs(900))
+        Self::new(limit, Duration::from_mins(15))
     }
 
     #[must_use]
     pub fn per_day(limit: u32) -> Self {
-        Self::new(limit, Duration::from_secs(86400))
+        Self::new(limit, Duration::from_hours(24))
     }
 
     fn rate_limit<T: std::hash::Hash>(&self, key: &T, res: &mut Response, ctrl: &mut FlowCtrl) {

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -35,5 +35,5 @@ pub fn html_action_result_card(title: &str, heading: &str, success: bool, messag
 /// Time-to-idle duration for the nickname cache.
 ///
 /// Entries not accessed within this window are evicted automatically.
-pub const NICK_CACHE_TTI: Duration = Duration::from_secs(30 * 60); // 30 minutes
+pub const NICK_CACHE_TTI: Duration = Duration::from_mins(30);
 pub type NickCache = nick_cache::NickTTICache;

--- a/game-core/src/ArenaGame.hpp
+++ b/game-core/src/ArenaGame.hpp
@@ -252,9 +252,7 @@ inline GameStateSnapshot ArenaGame::createSnapshot() const {
 		charSnapshot.ability1Cooldown = combat.ability1.cooldown;
 		charSnapshot.ability2Timer    = combat.skill2CooldownTimer;
 		charSnapshot.ability2Cooldown = combat.ability2.cooldown;
-		charSnapshot.swingProgress    = (combat.isAttacking && !combat.attackChain.empty())
-			? combat.swingTimer / combat.currentStage().duration
-			: 0.0f;
+		charSnapshot.swingProgress    = combat.computeSwingProgress();
 		charSnapshot.isGrounded       = physics.isGrounded;
 		charSnapshot.stamina    = stam.current;
 		charSnapshot.maxStamina = stam.maximum;

--- a/game-core/src/GameTypes.hpp
+++ b/game-core/src/GameTypes.hpp
@@ -136,6 +136,7 @@ struct InputState {
 	bool isAttacking;
 	bool isUsingAbility1;
 	bool isUsingAbility2;
+	bool isHoldingAbility2;   // steady "F held" state for channeled skills
 	bool isJumping;
 	bool isDodging;
 	bool isSprinting;
@@ -155,6 +156,7 @@ struct InputState {
 		, isAttacking(false)
 		, isUsingAbility1(false)
 		, isUsingAbility2(false)
+		, isHoldingAbility2(false)
 		, isJumping(false)
 		, isDodging(false)
 		, isSprinting(false)
@@ -169,6 +171,7 @@ struct InputState {
 		isAttacking = false;
 		isUsingAbility1 = false;
 		isUsingAbility2 = false;
+		isHoldingAbility2 = false;
 		isJumping = false;
 		isDodging = false;
 		hasTarget = false;

--- a/game-core/src/Presets.hpp
+++ b/game-core/src/Presets.hpp
@@ -31,14 +31,14 @@ namespace Presets {
 		},
 		.collider = {
 			.radius = 0.45f,
-			.height = 1.9f,            // tall with armor
+			.height = 1.9f,             // tall with armor
 		},
 		.stamina = {
 			.maxStamina        = 100.0f,
-			.baseRegenRate     = 40.0f,    // effective: 4.0/s (10% floor) to 40.0/s
-			.drainDelaySeconds = 1.5f,     // pause after full depletion
-			.sprintCostPerSec  = 15.0f,    // ~6.6s of continuous sprint
-			.jumpCost          = 8.0f,     // ~12 jumps from full
+			.baseRegenRate     = 40.0f, // effective: 4.0/s (10% floor) to 40.0/s
+			.drainDelaySeconds = 1.5f,  // pause after full depletion
+			.sprintCostPerSec  = 15.0f, // ~6.6s of continuous sprint
+			.jumpCost          = 8.0f,  // ~12 jumps from full
 		},
 		.combat = {
 			.baseDamage         = 18.0f,
@@ -47,19 +47,150 @@ namespace Presets {
 			.criticalMultiplier = 1.5f,
 			.attackChain = {
 				// Stage 0 — diagonal slice: quick opener
-				{ .damageMultiplier=0.8f, .range=3.0f, .duration=0.45f,
-				  .movementMultiplier=0.0f, .chainWindow=0.6f, .staminaCost=10.0f },
+				{
+					.damageMultiplier   = 0.8f,
+					.range              = 3.0f,
+					.duration           = 0.45f,
+					.movementMultiplier = 0.0f,
+					.chainWindow        = 0.6f,
+					.staminaCost        = 10.0f,
+				},
 				// Stage 1 — horizontal slice: mid combo
-				{ .damageMultiplier=0.9f, .range=3.0f, .duration=0.50f,
-				  .movementMultiplier=0.0f, .chainWindow=0.5f, .staminaCost=15.0f },
+				{
+					.damageMultiplier   = 0.9f,
+					.range              = 3.0f,
+					.duration           = 0.50f,
+					.movementMultiplier = 0.0f,
+					.chainWindow        = 0.5f,
+					.staminaCost        = 15.0f,
+				},
 				// Stage 2 — stab: heavy finisher, chain resets (chainWindow=0)
-				{ .damageMultiplier=1.6f, .range=3.0f, .duration=0.60f,
-				  .movementMultiplier=0.0f, .chainWindow=0.0f, .staminaCost=25.0f },
+				{
+					.damageMultiplier   = 1.6f,
+					.range              = 3.0f,
+					.duration           = 0.60f,
+					.movementMultiplier = 0.0f,
+					.chainWindow        = 0.0f,
+					.staminaCost        = 25.0f,
+				},
 			},
-			.skill1 = { .params = MeleeAOE{ .range=4.0f, .movementMultiplier=0.0f, .dmgMultiplier=1.8f },
-			            .cooldown=5.0f, .castDuration=0.7f, .staminaCost=20.0f },
-			.skill2 = { .params = MeleeAOE{ .range=4.0f, .movementMultiplier=0.7f, .dmgMultiplier=1.5f },
-			            .cooldown=10.0f, .castDuration=0.5f, .staminaCost=30.0f },
+			.skill1 = {
+				.params = MeleeAOE{
+					.range              = 4.0f,
+					.movementMultiplier = 0.0f,
+					.dmgMultiplier      = 1.8f,
+					.castDuration       = 0.7f,
+					.staminaCost        = 20.0f,
+				},
+				.cooldown = 5.0f,
+			},
+			.skill2 = {
+				.params = MeleeAOE{
+					.range              = 4.0f,
+					.movementMultiplier = 0.7f,
+					.dmgMultiplier      = 1.5f,
+					.castDuration       = 0.5f,
+					.staminaCost        = 30.0f,
+				},
+				.cooldown = 10.0f,
+			},
+		},
+	};
+
+	inline const CharacterPreset BARBARIAN = {
+		.health = {
+			.maxHealth  = 150.0f,
+			.armor      = 2.0f,
+			.resistance = 0.05f,
+		},
+		.movement = {
+			.movementSpeed    = 1.7f,
+			.rotationSpeed    = 14.0f,  // ~100ms for a 90° turn — mid-weight
+			.sprintMultiplier = 2.7f,   // moderate sprint
+			.crouchMultiplier = 0.5f,
+			.jumpVelocity     = 6.0f,   // decent jump
+			.dodgeVelocity    = 8.0f,   // short dodge — relies on aggression, not evasion
+			.airControlFactor = 0.2f,   // moderate air control
+			.acceleration     = 20.0f,  // ~65ms to walk, ~170ms to sprint
+			.deceleration     = 22.0f,  // ~55ms walk stop, ~175ms sprint slide — carries momentum
+			.mass             = 85.0f,
+			.friction         = 0.8f,   // slight slide on stop
+			.drag             = 0.0f,
+			.maxSpeed         = 9.0f,
+			.maxFallSpeed     = 58.0f,
+		},
+		.collider = {
+			.radius = 0.45f,
+			.height = 1.85f,            // big frame, slightly shorter than knight
+		},
+		.stamina = {
+			.maxStamina        = 110.0f,
+			.baseRegenRate     = 45.0f, // effective: 4.5/s (10% floor) to 45.0/s
+			.drainDelaySeconds = 1.2f,  // medium recovery window
+			.sprintCostPerSec  = 12.0f, // ~9s of continuous sprint
+			.jumpCost          = 7.0f,  // ~15 jumps from full
+		},
+		.combat = {
+			.baseDamage         = 25.0f,
+			.damageMultiplier   = 1.0f,
+			.criticalChance     = 0.20f,
+			.criticalMultiplier = 1.8f,
+			.attackChain = {
+				// Stage 0 — swing
+				{
+					.damageMultiplier   = 0.9f,
+					.range              = 3.5f,
+					.duration           = 0.65f,
+					.movementMultiplier = 0.2f,
+					.chainWindow        = 0.55f,
+					.staminaCost        = 10.0f,
+				},
+				// Stage 1 — stab
+				{
+					.damageMultiplier   = 1.2f,
+					.range              = 3.5f,
+					.duration           = 0.65f,
+					.movementMultiplier = 0.1f,
+					.chainWindow        = 0.5f,
+					.staminaCost        = 15.0f,
+				},
+				// Stage 2 — chop
+				{
+					.damageMultiplier   = 1.8f,
+					.range              = 3.5f,
+					.duration           = 1.0f,
+					.movementMultiplier = 0.0f,
+					.chainWindow        = 0.0f,
+					.staminaCost        = 20.0f,
+				},
+			},
+			// Skill 1 — spin attack: high-damage AOE, roots caster
+			.skill1 = {
+				.params = MeleeAOE{
+					.range              = 4.5f,
+					.movementMultiplier = 0.0f,
+					.dmgMultiplier      = 2.2f,
+					.castDuration       = 1.3f,
+					.staminaCost        = 25.0f,
+				},
+				.cooldown = 6.0f,
+			},
+			// Skill 2 — channeled spin: held while F is down, drains stamina.
+			// An axe angle rotates around the caster; each tick hits whatever
+			// the axe has swept past since the previous tick. A target at a
+			// fixed direction is hit once per full rotation.
+			.skill2 = {
+				.params = ChanneledCone{
+					.range                = 3.5f,
+					.rotationSpeed        = 12.566f,  // 4π rad/s = 2 full rotations per second
+					.tickInterval         = 0.1f,     // finer ticks give a smoother sweep — target is still hit once per rotation
+					.dmgPerTickMultiplier = 0.5f,     // each pass ≈ 0.5×base dmg; 2 passes/s → ~75 dmg over full 3s channel
+					.maxDuration          = 3.0f,
+					.staminaCostPerSec    = 35.0f,    // ~3.1s until full-stamina depletion
+					.movementMultiplier   = 0.5f,
+				},
+				.cooldown = 8.0f,
+			},
 		},
 	};
 
@@ -87,34 +218,62 @@ namespace Presets {
 		},
 		.collider = {
 			.radius = 0.35f,
-			.height = 1.75f,           // slimmer than knight
+			.height = 1.75f,            // slimmer than knight
 		},
 		.stamina = {
 			.maxStamina        = 120.0f,
-			.baseRegenRate     = 55.0f,    // effective: 5.5/s (10% floor) to 55.0/s
-			.drainDelaySeconds = 1.0f,     // short pause — recovers fast
-			.sprintCostPerSec  = 10.0f,    // ~12s of continuous sprint
-			.jumpCost          = 5.0f,     // ~24 jumps from full
+			.baseRegenRate     = 55.0f, // effective: 5.5/s (10% floor) to 55.0/s
+			.drainDelaySeconds = 1.0f,  // short pause — recovers fast
+			.sprintCostPerSec  = 10.0f, // ~12s of continuous sprint
+			.jumpCost          = 5.0f,  // ~24 jumps from full
 		},
 		.combat = {
 			.baseDamage         = 22.0f,
 			.damageMultiplier   = 1.0f,
-			.criticalChance     = 0.35f,   // high crit — glass cannon
+			.criticalChance     = 0.35f, // high crit — glass cannon
 			.criticalMultiplier = 2.0f,
 			.attackChain = {
 				// Stage 0 — chop: fast opener, mobile
-				{ .damageMultiplier=0.8f, .range=3.0f, .duration=0.5f,
-				  .movementMultiplier=0.4f, .chainWindow=0.5f, .staminaCost=8.0f },
+				{
+					.damageMultiplier   = 0.8f,
+					.range              = 3.0f,
+					.duration           = 0.5f,
+					.movementMultiplier = 0.4f,
+					.chainWindow        = 0.5f,
+					.staminaCost        = 8.0f,
+				},
 				// Stage 1 — slice: heavier finisher, chain resets (chainWindow=0)
-				{ .damageMultiplier=1.3f, .range=3.0f, .duration=0.6f,
-				  .movementMultiplier=0.3f, .chainWindow=0.0f, .staminaCost=14.0f },
+				{
+					.damageMultiplier   = 1.3f,
+					.range              = 3.0f,
+					.duration           = 0.6f,
+					.movementMultiplier = 0.3f,
+					.chainWindow        = 0.0f,
+					.staminaCost        = 14.0f,
+				},
 			},
 			// Skill 1 — dash stab: quick forward lunge
-			.skill1 = { .params = MeleeAOE{ .range=3.0f, .movementMultiplier=1.0f, .dmgMultiplier=1.6f },
-			            .cooldown=4.0f, .castDuration=0.40f, .staminaCost=15.0f },
+			.skill1 = {
+				.params = MeleeAOE{
+					.range              = 3.0f,
+					.movementMultiplier = 1.0f,
+					.dmgMultiplier      = 1.6f,
+					.castDuration       = 0.40f,
+					.staminaCost        = 15.0f,
+				},
+				.cooldown = 4.0f,
+			},
 			// Skill 2 — kick: close-range knockback/disengage tool
-			.skill2 = { .params = MeleeAOE{ .range=3.0f, .movementMultiplier=0.2f, .dmgMultiplier=1.4f },
-			            .cooldown=6.0f, .castDuration=0.45f, .staminaCost=12.0f },
+			.skill2 = {
+				.params = MeleeAOE{
+					.range              = 3.0f,
+					.movementMultiplier = 0.2f,
+					.dmgMultiplier      = 1.4f,
+					.castDuration       = 0.45f,
+					.staminaCost        = 12.0f,
+				},
+				.cooldown = 6.0f,
+			},
 		},
 	};
 /*

--- a/game-core/src/Skills.hpp
+++ b/game-core/src/Skills.hpp
@@ -4,21 +4,46 @@
 
 namespace ArenaGame {
 
+	// One-shot AOE cast. Player is locked for castDuration, then damage
+	// is applied once to every target in range.
 	struct MeleeAOE {
 		float range;
 		float movementMultiplier;  // 0=rooted, 1=full movement during skill
 		float dmgMultiplier;
+		float castDuration;        // seconds the caster is locked after triggering
+		float staminaCost;         // flat cost consumed when the cast completes
 	};
 
-	using SkillVariant = std::variant<MeleeAOE>;
+	// Channeled spinning-sweep attack. An axe angle rotates around the
+	// caster at rotationSpeed (rad/s, cumulative offset from caster forward).
+	// Each tick, damage is applied to every target whose direction-from-
+	// caster falls inside the arc swept since the previous tick. Ends on
+	// key release, stamina depletion, maxDuration, or death.
+	//
+	// Notes:
+	//   - Coverage is continuous: a stationary target at a given direction
+	//     is hit exactly once per full rotation, independent of tickInterval.
+	//   - The caster can still steer by turning; the swept arc is a local
+	//     offset that follows the caster's current forward.
+	struct ChanneledCone {
+		float range;
+		float rotationSpeed;        // axe angular velocity (rad/s) around the caster
+		float tickInterval;         // seconds between damage ticks
+		float dmgPerTickMultiplier; // applied per tick (vs CombatController::baseDamage)
+		float maxDuration;          // hard cap on channel length (seconds)
+		float staminaCostPerSec;    // continuous drain while channeling
+		float movementMultiplier;   // 0=rooted, 1=full movement during channel
+	};
+
+	using SkillVariant = std::variant<MeleeAOE, ChanneledCone>;
 
 	// Pure preset data — no mutable fields, no methods.
 	// All runtime state (timers, hitPending) lives on CombatController.
+	// Only fields universal to every variant belong here; variant-specific
+	// timings / costs live inside the variant struct itself.
 	struct SkillDefinition {
 		SkillVariant params;
-		float cooldown     = 0.0f;  // cooldown duration after cast ends
-		float castDuration = 0.0f;  // how long player is locked into this skill
-		float staminaCost  = 0.0f;  // stamina consumed when cast completes
+		float cooldown = 0.0f;  // cooldown duration after the skill ends
 	};
 
 	struct AttackStage {

--- a/game-core/src/components/CombatController.hpp
+++ b/game-core/src/components/CombatController.hpp
@@ -103,6 +103,38 @@ struct CombatController {
 		return canUseAbilities && !isAttacking && skill2CooldownTimer <= 0.0f && !isAbility2Casting();
 	}
 
+	// 0..1 progress through the currently visible weapon swing — drives the
+	// frontend trail ribbon. Non-zero during normal attacks, one-shot skill
+	// casts, and channeled sweeps; monotonically increases within each.
+	// The ribbon uses a 0.5-unit rolling window to prune old points.
+	float computeSwingProgress() const {
+		if (isAttacking && !attackChain.empty())
+			return swingTimer / currentStage().duration;
+
+		// One-shot skill cast: castTimer counts down from castDuration to 0.
+		if (skill1CastTimer > 0.0f) {
+			const auto* m = std::get_if<MeleeAOE>(&ability1.params);
+			if (m && m->castDuration > 0.0f)
+				return 1.0f - skill1CastTimer / m->castDuration;
+		}
+		if (skill2CastTimer > 0.0f) {
+			const auto* m = std::get_if<MeleeAOE>(&ability2.params);
+			if (m && m->castDuration > 0.0f)
+				return 1.0f - skill2CastTimer / m->castDuration;
+		}
+
+		// Channeled skill: progress grows with elapsed time (no cap). The scale
+		// paired with TAIL_FRACTION=0.5 in SwingTrail.ts gives ~0.25s of ribbon,
+		// matching the visual length of a normal attack swing.
+		constexpr float kChannelSwingSeconds = 0.5f;
+		if (skill1Channeling)
+			return skill1ChannelElapsed / kChannelSwingSeconds;
+		if (skill2Channeling)
+			return skill2ChannelElapsed / kChannelSwingSeconds;
+
+		return 0.0f;
+	}
+
 	// ── State transitions (called by CombatSystem) ───────────────────────────
 
 	// Begin the current stage's swing.

--- a/game-core/src/components/CombatController.hpp
+++ b/game-core/src/components/CombatController.hpp
@@ -70,6 +70,16 @@ struct CombatController {
 	float skill2CastTimer     = 0.0f;
 	bool  skill2HitPending    = false;
 
+	// Channeled-skill runtime state (only used for ChanneledCone skills)
+	bool  skill1Channeling      = false;
+	float skill1ChannelElapsed  = 0.0f;  // total time channel has been active
+	float skill1TickTimer       = 0.0f;  // counts up to ChanneledCone::tickInterval
+	float skill1SpinAngle       = 0.0f;  // cumulative axe angle (rad) offset from caster forward
+	bool  skill2Channeling      = false;
+	float skill2ChannelElapsed  = 0.0f;
+	float skill2TickTimer       = 0.0f;
+	float skill2SpinAngle       = 0.0f;
+
 	// ── Capability flags ─────────────────────────────────────────────────────
 
 	bool canAttack       = true;
@@ -89,18 +99,22 @@ struct CombatController {
 
 	bool isAbility1Casting() const { return skill1CastTimer > 0.0f; }
 	bool isAbility2Casting() const { return skill2CastTimer > 0.0f; }
+	bool isAbility1Channeling() const { return skill1Channeling; }
+	bool isAbility2Channeling() const { return skill2Channeling; }
+	bool isAbility1Active() const { return isAbility1Casting() || isAbility1Channeling(); }
+	bool isAbility2Active() const { return isAbility2Casting() || isAbility2Channeling(); }
 
-	// Ready to accept an attack input — not mid-swing, not casting, and attacks are enabled.
+	// Ready to accept an attack input — not mid-swing, not casting/channeling, and attacks are enabled.
 	bool canPerformAttack() const {
 		return canAttack && !isAttacking && !attackChain.empty()
-			&& !isAbility1Casting() && !isAbility2Casting();
+			&& !isAbility1Active() && !isAbility2Active();
 	}
 
 	bool canUseAbility1() const {
-		return canUseAbilities && !isAttacking && skill1CooldownTimer <= 0.0f && !isAbility1Casting();
+		return canUseAbilities && !isAttacking && skill1CooldownTimer <= 0.0f && !isAbility1Active();
 	}
 	bool canUseAbility2() const {
-		return canUseAbilities && !isAttacking && skill2CooldownTimer <= 0.0f && !isAbility2Casting();
+		return canUseAbilities && !isAttacking && skill2CooldownTimer <= 0.0f && !isAbility2Active();
 	}
 
 	// 0..1 progress through the currently visible weapon swing — drives the

--- a/game-core/src/cxx_bridge.cpp
+++ b/game-core/src/cxx_bridge.cpp
@@ -84,12 +84,13 @@ void GameBridge::set_player_input(uint32_t id, const PlayerInput& input) {
     ::ArenaGame::InputState state;
     state.movementDirection = from_vec3(input.movement);
     state.lookDirection     = from_vec3(input.look_direction);
-    state.isAttacking     = input.attacking;
-    state.isJumping       = input.jumping;
-    state.isUsingAbility1 = input.ability1;
-    state.isUsingAbility2 = input.ability2;
-    state.isDodging       = input.dodging;
-    state.isSprinting     = input.sprinting;
+    state.isAttacking      = input.attacking;
+    state.isJumping        = input.jumping;
+    state.isUsingAbility1  = input.ability1;
+    state.isUsingAbility2  = input.ability2;
+    state.isHoldingAbility2 = input.ability2_held;
+    state.isDodging        = input.dodging;
+    state.isSprinting      = input.sprinting;
     game.setPlayerInput(id, state);
 }
 

--- a/game-core/src/systems/CharacterControllerSystem.hpp
+++ b/game-core/src/systems/CharacterControllerSystem.hpp
@@ -75,8 +75,13 @@ inline void CharacterControllerSystem::processCharacterMovement(
 		return;
 	}
 
-	// Skip if movement is disabled (stunned, casting, etc.)
+	// Skip if movement is disabled (stunned, rooted cast, etc.). Zero
+	// horizontal velocity so prior momentum doesn't carry the character
+	// through the root — otherwise pressing a rooting skill while running
+	// leaves the player sliding for the length of the cast.
 	if (!controller.canMove) {
+		physics.velocity.x = 0.0f;
+		physics.velocity.z = 0.0f;
 		return;
 	}
 
@@ -136,7 +141,11 @@ inline void CharacterControllerSystem::processCharacterMovement(
 	// Update movement state. While coasting to a stop, stay in Walking until
 	// horizontal speed drops below a small threshold so animations don't pop
 	// to Idle mid-slide.
-	if (hasInput) {
+	// CombatSystem owns the Casting state during channels/casts with
+	// movementMultiplier > 0 (canMove stays true); don't stamp over it.
+	if (controller.state == CharacterState::Casting) {
+		// preserved
+	} else if (hasInput) {
 		controller.setState(controller.isSprinting
 			? CharacterState::Sprinting
 			: CharacterState::Walking);

--- a/game-core/src/systems/CombatSystem.hpp
+++ b/game-core/src/systems/CombatSystem.hpp
@@ -146,9 +146,32 @@ private:
 	                  Components::NetworkEventsComponent* ne,
 	                  entt::entity entity, uint8_t slot);
 
+	void startChannel(Components::CombatController& comcon,
+	                  Components::CharacterController& charcon,
+	                  const SkillDefinition& def,
+	                  bool& channeling, float& channelElapsed, float& tickTimer,
+	                  float& spinAngle,
+	                  Components::NetworkEventsComponent* ne,
+	                  entt::entity entity, uint8_t slot);
+
+	void tickChannelSlot(bool& channeling, float& channelElapsed, float& tickTimer,
+	                     float& spinAngle, float& cooldownTimer,
+	                     const SkillDefinition& def, bool isHeld,
+	                     entt::entity entity,
+	                     Components::CombatController& combat,
+	                     Components::CharacterController& controller,
+	                     Components::Health& health,
+	                     Components::Transform& trans,
+	                     Components::PhysicsBody& physics,
+	                     Components::Stamina* stamina);
+
 	// ── Hit detection ────────────────────────────────────────────────────
 	void hitAllInRange(SkillContext& ctx, float range, float dmgMultiplier);
 	void hitInArc(SkillContext& ctx, float range, float dmgMultiplier, float attackAngle);
+	// Swept-arc hit: damages targets whose direction-from-caster (in the
+	// caster's local frame) falls within [sweepFromLocal, sweepToLocal] rad.
+	void hitInSweep(SkillContext& ctx, float range, float dmgMultiplier,
+	                float sweepFromLocal, float sweepToLocal);
 	void executeSkill(const SkillDefinition& skill, SkillContext& ctx);
 
 	// ── Utilities ────────────────────────────────────────────────────────
@@ -176,25 +199,32 @@ inline void CombatSystem::update(float deltaTime) {
 
 inline void CombatSystem::applySkillMovementLock(
 		Components::CharacterController& c, const SkillVariant& params) {
+	auto apply = [&](float mult) {
+		if (mult == 0.0f)
+			c.canMove = false;
+		else if (mult < 1.0f)
+			c.activeMovementMultiplier = mult;
+	};
 	std::visit(overloaded{
-		[&](const MeleeAOE& s) {
-			if (s.movementMultiplier == 0.0f)
-				c.canMove = false;
-			else if (s.movementMultiplier < 1.0f)
-				c.activeMovementMultiplier = s.movementMultiplier;
-		}
+		[&](const MeleeAOE& s)       { apply(s.movementMultiplier); },
+		// Lock rotation during the spin: the sweep arc is in the caster's
+		// local frame, so letting input steer yaw makes the arc oscillate
+		// with WASD and causes targets to slip out of the per-tick window.
+		[&](const ChanneledCone& s)  { apply(s.movementMultiplier); c.disableRotation(); }
 	}, params);
 }
 
 inline void CombatSystem::removeSkillMovementLock(
 		Components::CharacterController& c, const SkillVariant& params) {
+	auto remove = [&](float mult) {
+		if (mult == 0.0f)
+			c.canMove = true;
+		else if (mult > 0.0f && mult < 1.0f)
+			c.activeMovementMultiplier = 1.0f;
+	};
 	std::visit(overloaded{
-		[&](const MeleeAOE& s) {
-			if (s.movementMultiplier == 0.0f)
-				c.canMove = true;
-			else if (s.movementMultiplier > 0.0f && s.movementMultiplier < 1.0f)
-				c.activeMovementMultiplier = 1.0f;
-		}
+		[&](const MeleeAOE& s)       { remove(s.movementMultiplier); },
+		[&](const ChanneledCone& s)  { remove(s.movementMultiplier); c.enableRotation(); }
 	}, params);
 }
 
@@ -207,11 +237,46 @@ inline void CombatSystem::triggerSkill(
 		float& castTimer, bool& hitPending,
 		Components::NetworkEventsComponent* ne,
 		entt::entity entity, uint8_t slot) {
-	castTimer  = def.castDuration;
+	// triggerSkill is only invoked for one-shot variants (MeleeAOE).
+	// Channeled skills go through startChannel.
+	const auto& melee = std::get<MeleeAOE>(def.params);
+	castTimer  = melee.castDuration;
 	hitPending = true;
 	charcon.setState(CharacterState::Casting);
 	applySkillMovementLock(charcon, def.params);
 	if (ne) ne->events.push_back(NetEvents::SkillUsedEvent{ getPlayerID(entity), slot });
+}
+
+inline void CombatSystem::startChannel(
+		Components::CombatController& comcon,
+		Components::CharacterController& charcon,
+		const SkillDefinition& def,
+		bool& channeling, float& channelElapsed, float& tickTimer,
+		float& spinAngle,
+		Components::NetworkEventsComponent* ne,
+		entt::entity entity, uint8_t slot) {
+	channeling     = true;
+	channelElapsed = 0.0f;
+	tickTimer      = 0.0f;
+	spinAngle      = 0.0f;  // axe starts at caster forward
+	charcon.setState(CharacterState::Casting);
+	applySkillMovementLock(charcon, def.params);
+	if (ne) ne->events.push_back(NetEvents::SkillUsedEvent{ getPlayerID(entity), slot });
+}
+
+// Returns true if the skill variant is a held/channeled type.
+inline bool isChanneledSkill(const SkillDefinition& def) {
+	return std::holds_alternative<ChanneledCone>(def.params);
+}
+
+// Stamina required to initiate the skill. One-shot skills pay a flat cost
+// on completion (MeleeAOE::staminaCost) but still gate start on it via
+// canAfford. Channeled skills pay over time and start at no entry cost.
+inline float skillEntryStaminaCost(const SkillDefinition& def) {
+	return std::visit(overloaded{
+		[](const MeleeAOE& s)      -> float { return s.staminaCost; },
+		[](const ChanneledCone&)   -> float { return 0.0f; }
+	}, def.params);
 }
 
 inline void CombatSystem::processInputAttacks() {
@@ -232,7 +297,7 @@ inline void CombatSystem::processInputAttacks() {
 		if (!health.isAlive()) return;
 
 		// Buffer input while committed to an action. Last input wins (Skill2 > Skill1 > Attack).
-		if (comcon.isAttacking || comcon.isAbility1Casting() || comcon.isAbility2Casting()) {
+		if (comcon.isAttacking || comcon.isAbility1Active() || comcon.isAbility2Active()) {
 			if (charcon.input.isAttacking)      comcon.bufferedAction = CombatController::BufferedAction::Attack;
 			if (charcon.input.isUsingAbility1)  comcon.bufferedAction = CombatController::BufferedAction::Skill1;
 			if (charcon.input.isUsingAbility2)  comcon.bufferedAction = CombatController::BufferedAction::Skill2;
@@ -249,10 +314,10 @@ inline void CombatSystem::processInputAttacks() {
 					|| !stamina.canAfford(comcon.currentStage().staminaCost)))
 			toFire = CombatController::BufferedAction::None;
 		if (toFire == CombatController::BufferedAction::Skill1
-				&& !stamina.canAfford(comcon.ability1.staminaCost))
+				&& !stamina.canAfford(skillEntryStaminaCost(comcon.ability1)))
 			toFire = CombatController::BufferedAction::None;
 		if (toFire == CombatController::BufferedAction::Skill2
-				&& !stamina.canAfford(comcon.ability2.staminaCost))
+				&& !stamina.canAfford(skillEntryStaminaCost(comcon.ability2)))
 			toFire = CombatController::BufferedAction::None;
 
 		const bool wantsAttack = charcon.input.isAttacking     || toFire == CombatController::BufferedAction::Attack;
@@ -260,13 +325,27 @@ inline void CombatSystem::processInputAttacks() {
 		const bool wantsSkill2 = charcon.input.isUsingAbility2 || toFire == CombatController::BufferedAction::Skill2;
 
 		// Priority: Skill2 > Skill1 > Attack
-		if (wantsSkill2 && comcon.canUseAbility2() && stamina.canAfford(comcon.ability2.staminaCost)) {
-			triggerSkill(comcon, charcon, comcon.ability2,
-			             comcon.skill2CastTimer, comcon.skill2HitPending, ne, entity, 2);
+		if (wantsSkill2 && comcon.canUseAbility2() && stamina.canAfford(skillEntryStaminaCost(comcon.ability2))) {
+			if (isChanneledSkill(comcon.ability2)) {
+				startChannel(comcon, charcon, comcon.ability2,
+				             comcon.skill2Channeling, comcon.skill2ChannelElapsed,
+				             comcon.skill2TickTimer, comcon.skill2SpinAngle,
+				             ne, entity, 2);
+			} else {
+				triggerSkill(comcon, charcon, comcon.ability2,
+				             comcon.skill2CastTimer, comcon.skill2HitPending, ne, entity, 2);
+			}
 
-		} else if (wantsSkill1 && comcon.canUseAbility1() && stamina.canAfford(comcon.ability1.staminaCost)) {
-			triggerSkill(comcon, charcon, comcon.ability1,
-			             comcon.skill1CastTimer, comcon.skill1HitPending, ne, entity, 1);
+		} else if (wantsSkill1 && comcon.canUseAbility1() && stamina.canAfford(skillEntryStaminaCost(comcon.ability1))) {
+			if (isChanneledSkill(comcon.ability1)) {
+				startChannel(comcon, charcon, comcon.ability1,
+				             comcon.skill1Channeling, comcon.skill1ChannelElapsed,
+				             comcon.skill1TickTimer, comcon.skill1SpinAngle,
+				             ne, entity, 1);
+			} else {
+				triggerSkill(comcon, charcon, comcon.ability1,
+				             comcon.skill1CastTimer, comcon.skill1HitPending, ne, entity, 1);
+			}
 
 		} else if (wantsAttack && comcon.canPerformAttack() && stamina.canAfford(comcon.currentStage().staminaCost)) {
 			const AttackStage& stage = comcon.currentStage();
@@ -322,9 +401,59 @@ inline void CombatSystem::hitInArc(SkillContext& ctx, float range, float dmgMult
 	});
 }
 
+// Swept-arc hit: sweepFromLocal and sweepToLocal are axe angles in the
+// caster's LOCAL frame (radians, 0 = caster forward). A target is hit if
+// its direction-from-caster projected into the caster's local frame falls
+// inside that arc. Sweep width >= 2π clamps to full-circle.
+inline void CombatSystem::hitInSweep(
+		SkillContext& ctx, float range, float dmgMultiplier,
+		float sweepFromLocal, float sweepToLocal) {
+	constexpr float kTwoPi = 6.283185307179586f;
+	auto targets = m_registry->view<Components::Transform, Components::Health>();
+
+	const float yaw = ctx.attackerTransform.rotation.y;
+	float sweepWidth = sweepToLocal - sweepFromLocal;
+	// Normalize width into [0, 2π]; if negative or zero, nothing is hit.
+	if (sweepWidth <= 0.0f) return;
+	if (sweepWidth >= kTwoPi) sweepWidth = kTwoPi;  // full circle
+
+	// Sweep midpoint in local frame; we'll compare each target's local
+	// direction against this midpoint via shortest signed arc distance.
+	const float midLocal = sweepFromLocal + sweepWidth * 0.5f;
+	const float halfWidth = sweepWidth * 0.5f;
+
+	targets.each([&](entt::entity target,
+					 Components::Transform& targetTransform,
+					 Components::Health&    targetHealth) {
+		if (target == ctx.attackerEntity) return;
+		if (!targetHealth.isAlive()) return;
+
+		const Vector3D delta = targetTransform.position - ctx.attackerTransform.position;
+		const float distSq = delta.x * delta.x + delta.z * delta.z;
+		if (distSq > range * range) return;
+
+		// Transform.getForwardDirection uses (sin(yaw), 0, cos(yaw)), so the
+		// world-space angle of a direction (dx, dz) is atan2(dx, dz).
+		const float worldAngle = std::atan2(delta.x, delta.z);
+		// Direction relative to caster's current forward.
+		float localAngle = worldAngle - yaw;
+		// Shortest signed arc distance from sweep midpoint.
+		float diff = localAngle - midLocal;
+		while (diff >  3.141592653589793f) diff -= kTwoPi;
+		while (diff < -3.141592653589793f) diff += kTwoPi;
+		if (std::abs(diff) > halfWidth) return;
+
+		float dmg = calculateCombatDamage(ctx.combatCon, dmgMultiplier);
+		ctx.pendingHits.push({ctx.attackerEntity, target, dmg});
+	});
+}
+
 inline void CombatSystem::executeSkill(const SkillDefinition& skill, SkillContext& ctx) {
 	std::visit(overloaded {
-		[&](const MeleeAOE& s) { hitAllInRange(ctx, s.range, s.dmgMultiplier); }
+		[&](const MeleeAOE& s) { hitAllInRange(ctx, s.range, s.dmgMultiplier); },
+		// ChanneledCone is driven per-tick from tickChannelSlot, not via the
+		// one-shot cast → executeSkill path. Nothing to do here.
+		[&](const ChanneledCone&) { (void)ctx; }
 	}, skill.params);
 }
 
@@ -444,15 +573,73 @@ inline void CombatSystem::tickSkillSlot(
 	cooldownTimer = def.cooldown;
 
 	if (hitPending) {
-		// Consume stamina when cast completes
+		// Consume stamina when cast completes. tickSkillSlot only runs for
+		// one-shot (MeleeAOE) skills — channeled skills never set castTimer.
 		if (auto* stamina = m_registry->try_get<Components::Stamina>(entity))
-			stamina->consume(def.staminaCost);
+			stamina->consume(std::get<MeleeAOE>(def.params).staminaCost);
 		if (health.isAlive()) {
 			SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
 			executeSkill(def, ctx);
 		}
 		hitPending = false;
 	}
+
+	if (!controller.isDead()) {
+		removeSkillMovementLock(controller, def.params);
+		controller.restoreMovementState();
+	}
+}
+
+inline void CombatSystem::tickChannelSlot(
+		bool& channeling, float& channelElapsed, float& tickTimer,
+		float& spinAngle, float& cooldownTimer,
+		const SkillDefinition& def, bool isHeld,
+		entt::entity entity,
+		Components::CombatController& combat,
+		Components::CharacterController& controller,
+		Components::Health& health,
+		Components::Transform& trans,
+		Components::PhysicsBody& physics,
+		Components::Stamina* stamina) {
+	if (!channeling) return;
+
+	const auto* channel = std::get_if<ChanneledCone>(&def.params);
+	if (!channel) { channeling = false; return; }  // defensive
+
+	// Drain stamina continuously
+	if (stamina) stamina->consume(channel->staminaCostPerSec * m_deltaTime);
+
+	// Advance the axe's angular position every frame so the sweep tracks
+	// time, not tick count. Each damage tick hits the arc covered since
+	// the previous tick — this is what makes targets register once per
+	// pass rather than once per frame.
+	channelElapsed += m_deltaTime;
+	tickTimer      += m_deltaTime;
+	spinAngle      += channel->rotationSpeed * m_deltaTime;
+
+	// Fire damage ticks for each interval that has elapsed.
+	while (tickTimer >= channel->tickInterval && health.isAlive()) {
+		tickTimer -= channel->tickInterval;
+		const float sweepWidth = channel->rotationSpeed * channel->tickInterval;
+		const float sweepTo    = spinAngle - tickTimer * channel->rotationSpeed;
+		const float sweepFrom  = sweepTo - sweepWidth;
+		SkillContext ctx{ *m_registry, entity, trans, physics, controller, combat, m_pendingHits };
+		hitInSweep(ctx, channel->range, channel->dmgPerTickMultiplier, sweepFrom, sweepTo);
+	}
+
+	// End conditions: released, stamina depleted, max duration, or death.
+	const bool stamOut   = stamina && stamina->current <= 0.0f;
+	const bool timedOut  = channelElapsed >= channel->maxDuration;
+	const bool dead      = !health.isAlive();
+	const bool shouldEnd = !isHeld || stamOut || timedOut || dead;
+
+	if (!shouldEnd) return;
+
+	channeling     = false;
+	channelElapsed = 0.0f;
+	tickTimer      = 0.0f;
+	spinAngle      = 0.0f;
+	cooldownTimer  = def.cooldown;
 
 	if (!controller.isDead()) {
 		removeSkillMovementLock(controller, def.params);
@@ -481,6 +668,18 @@ inline void CombatSystem::updateCooldowns(float deltaTime) {
 		              combat.ability1, entity, combat, controller, health, trans, physics);
 		tickSkillSlot(combat.skill2CastTimer, combat.skill2HitPending, combat.skill2CooldownTimer,
 		              combat.ability2, entity, combat, controller, health, trans, physics);
+
+		auto* stamina = m_registry->try_get<Stamina>(entity);
+		// Slot 1 has no held input wired yet — channel never starts for it,
+		// so isHeld=false is safe until a channeled skill1 is introduced.
+		tickChannelSlot(combat.skill1Channeling, combat.skill1ChannelElapsed, combat.skill1TickTimer,
+		                combat.skill1SpinAngle, combat.skill1CooldownTimer, combat.ability1,
+		                false,
+		                entity, combat, controller, health, trans, physics, stamina);
+		tickChannelSlot(combat.skill2Channeling, combat.skill2ChannelElapsed, combat.skill2TickTimer,
+		                combat.skill2SpinAngle, combat.skill2CooldownTimer, combat.ability2,
+		                controller.input.isHoldingAbility2,
+		                entity, combat, controller, health, trans, physics, stamina);
 	});
 }
 

--- a/game-core/src/systems/StaminaSystem.hpp
+++ b/game-core/src/systems/StaminaSystem.hpp
@@ -78,11 +78,12 @@ inline void StaminaSystem::lateUpdate(float deltaTime) {
 			}
 		}
 
-		// 4. No regen while actively spending stamina
+		// 4. No regen while actively spending stamina. Channeled skills
+		// drain per-second, so they count as "active" just like casts.
 		if (controller.isSprinting) return;
 		if (combat.isAttacking) return;
-		if (combat.isAbility1Casting()) return;
-		if (combat.isAbility2Casting()) return;
+		if (combat.isAbility1Active()) return;
+		if (combat.isAbility2Active()) return;
 
 		// 5. Scaled regen with 10% minimum floor
 		float ratio = stamina.current / stamina.maximum;


### PR DESCRIPTION
Move the swingProgress computation out of ArenaGame::createSnapshot and into CombatController::computeSwingProgress, then broaden it so skill casts and channels produce a non-zero progress value as well.

The frontend SwingTrail consumes swingProgress to emit the trailing ribbon behind the weapon. Previously it was only populated for normal attack chains, so skills swung silently. Now:
  - one-shot casts report 1 - castTimer/castDuration
  - channeled skills report elapsed / 0.5s (matches the ribbon's TAIL_FRACTION=0.5 window, giving ~0.25s of visible trail like a normal swing)